### PR TITLE
rawfiles: fix compilation without sndfile

### DIFF
--- a/devices/rawfiles/rawfiles.h
+++ b/devices/rawfiles/rawfiles.h
@@ -22,7 +22,6 @@
 #ifndef	__RAW_FILES__
 #define	__RAW_FILES__
 
-#include        <sndfile.h>
 #include        "ringbuffer.h"
 #include        "device-handler.h"
 #include        <thread>


### PR DESCRIPTION
Compiling sndfile without sndfile fails with the following message:
In file included from /../dab-cmdline/devices/rawfiles/rawfiles.cpp:33:0:
/../dab-cmdline/devices/rawfiles/rawfiles.h:25:28: fatal error: sndfile.h: No such file or directory

It seems there is no real dependency for sndfile on rawfiles, so remove that header to allow compilation.