### PR TITLE
device handlers: make sure they print messages on stderr

### DIFF
--- a/devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -74,7 +74,7 @@ int16_t	deviceCount;
 int32_t	r;
 int16_t	i;
 
-	fprintf (stdout, "going for rtlsdr %d %d\n", frequency, gain);
+	fprintf (stderr, "going for rtlsdr %d %d\n", frequency, gain);
 	this	-> frequency	= frequency;
 	this	-> ppmCorrection	= ppmCorrection;
 	this	-> gain		= gain;
@@ -146,22 +146,22 @@ int16_t	i;
 	}
 
 	r			= this -> rtlsdr_get_sample_rate (device);
-	fprintf (stdout, "samplerate set to %d\n", r);
+	fprintf (stderr, "samplerate set to %d\n", r);
 	rtlsdr_set_tuner_gain_mode (device, 1);
 
 	gainsCount	= rtlsdr_get_tuner_gains (device, NULL);
-	fprintf (stdout, "Supported gain values (%d): ", gainsCount);
+	fprintf (stderr, "Supported gain values (%d): ", gainsCount);
 	gains		= new int [gainsCount];
 	gainsCount	= rtlsdr_get_tuner_gains (device, gains);
 	for (i = 0; i < gainsCount; i ++)
-	   fprintf (stdout, "%d.%d ", gains [i] / 10, gains [i] % 10);
-	fprintf (stdout, "\n");
+	   fprintf (stderr, "%d.%d ", gains [i] / 10, gains [i] % 10);
+	fprintf (stderr, "\n");
 	gain		= gain * gainsCount / 100;
 	if (ppmCorrection != 0)
 	   rtlsdr_set_freq_correction (device, ppmCorrection);
 	if (autogain)
 	   rtlsdr_set_agc_mode (device, 1);
-	fprintf (stdout, "effective gain: index %d, gain %d\n",
+	fprintf (stderr, "effective gain: index %d, gain %d\n",
 	                                   gain, gains [gain]);
 	rtlsdr_set_tuner_gain (device, gains [gain]);
 	_I_Buffer		= new RingBuffer<uint8_t>(1024 * 1024);

--- a/devices/sdrplay-handler/sdrplay-handler.cpp
+++ b/devices/sdrplay-handler/sdrplay-handler.cpp
@@ -121,7 +121,7 @@ ULONG APIkeyValue_length = 255;
 	if (deviceIndex >= numofDevs)
 	   this -> deviceIndex = 0;
 	hwVersion = devDesc [deviceIndex]. hwVer;
-	fprintf (stdout, "sdrdevice found = %s, hw Version = %d\n",
+	fprintf (stderr, "sdrdevice found = %s, hw Version = %d\n",
 	                              devDesc [deviceIndex]. SerNo, hwVersion);
 	my_mir_sdr_SetDeviceIdx (deviceIndex);
 
@@ -136,7 +136,7 @@ ULONG APIkeyValue_length = 255;
 //
 	my_mir_sdr_SetGr (102 - theGain, 1, 0);
 	running		= false;
-	fprintf (stdout, "Loading sdrplay ging goed\n");
+	fprintf (stderr, "Loading sdrplay ging goed\n");
 }
 
 	sdrplayHandler::~sdrplayHandler	(void) {
@@ -269,7 +269,7 @@ int	localGain	= 102 - theGain;
 	if (running)
 	   return true;
 	autogain	= false;
-	fprintf (stdout, "begin met restart %d %d %d\n",
+	fprintf (stderr, "begin met restart %d %d %d\n",
 	                         frequency, localGain, autogain);
 	err	= my_mir_sdr_StreamInit (&localGain,
 	                                 double (inputRate) / MHz_1,
@@ -284,7 +284,7 @@ int	localGain	= 102 - theGain;
 	                                 (mir_sdr_GainChangeCallback_t)myGainChangeCallback,
 	                                 this);
 	if (err != mir_sdr_Success) {
-	   fprintf (stdout, "Error %d on streamInit\n", err);
+	   fprintf (stderr, "Error %d on streamInit\n", err);
 	   return false;
 	}
 


### PR DESCRIPTION
When using example3 with rtsdr-handler the output contains some informational messages.
Eg. cat out.stream | strings | head
going for rtlsdr 188928000 35
samplerate set to 2048000
Supported gain values (29): 0.0 0.9 1.4 2.7 3.7 7.7 8.7 12.5 14.4 15.7 16.6 19.7 20.7 22.9 25.4 28.0 29.7 32.8 33.8 36.4 37.2 38.6 40.2 42.1 43.4 43.9 44.5 48.0 49.6
effective gain: index 10, gain 166
...

This commit changes all handlers to output messages to stderr, so example3 output will contain only raw pcm samples.