### PR TITLE
examples: fix Mode check

### DIFF
--- a/example-1/main.cpp
+++ b/example-1/main.cpp
@@ -191,7 +191,7 @@ deviceHandler	*theDevice;
 
 	      case 'M':
 	         theMode	= atoi (optarg);
-	         if (!(theMode == 1) || (theMode == 2) || (theMode == 4))
+	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
 	            theMode = 1; 
 	         break;
 

--- a/example-2/main.cpp
+++ b/example-2/main.cpp
@@ -266,7 +266,7 @@ bool	err;
 
 	      case 'M':
 	         theMode	= atoi (optarg);
-	         if (!(theMode == 1) || (theMode == 2) || (theMode == 4))
+	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
 	            theMode = 1; 
 	         break;
 

--- a/example-3/main.cpp
+++ b/example-3/main.cpp
@@ -239,7 +239,7 @@ bool	err;
 
 	      case 'M':
 	         theMode	= atoi (optarg);
-	         if (!(theMode == 1) || (theMode == 2) || (theMode == 4))
+	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
 	            theMode = 1; 
 	         break;
 

--- a/example-4/main.cpp
+++ b/example-4/main.cpp
@@ -241,7 +241,7 @@ bool	err;
 
 	      case 'M':
 	         theMode	= atoi (optarg);
-	         if (!(theMode == 1) || (theMode == 2) || (theMode == 4))
+	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
 	            theMode = 1; 
 	         break;
 

--- a/example-5/main.cpp
+++ b/example-5/main.cpp
@@ -267,7 +267,7 @@ bool	err;
 
 	      case 'M':
 	         theMode	= atoi (optarg);
-	         if (!(theMode == 1) || (theMode == 2) || (theMode == 4))
+	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
 	            theMode = 1; 
 	         break;
 


### PR DESCRIPTION
It seems that mode check should fallback to mode 1 only when invalid mode provided to command line.
Fallback to mode 1 only if mode is not one of 1,2,4.