### PR TITLE
ofdm: use zero Khz correction

### DIFF
--- a/library/src/ofdm/ofdm-processor.cpp
+++ b/library/src/ofdm/ofdm-processor.cpp
@@ -351,10 +351,8 @@ int		index_attempts		= 0;
 	                                  estimateOffset (ofdmBuffer);
 	         if (correction != 100) {
 	            coarseCorrector += correction * carrierDiff;
-	            if (coarseCorrector > Khz (35))
-	               coarseCorrector = Khz (34);
-	            if (coarseCorrector <= - Khz (35))
-	               coarseCorrector = - Khz (34);
+	            if (abs (coarseCorrector) > Khz (35))
+	               coarseCorrector = 0;
 	         }
 	      }
 //


### PR DESCRIPTION
just like welle.io does https://github.com/AlbrechtL/welle.io/blob/master/src/ofdm/ofdm-processor.cpp#L401-L405

There are reports from several people, mentioning that after applying that patch, sync seems much faster.
