### PR TITLE
Update languages tables 9 and add table 10

### DIFF
--- a/simple-dab/simple-dab.cpp
+++ b/simple-dab/simple-dab.cpp
@@ -648,17 +648,107 @@ const char *table9 [] = {
 "Swedish",
 "Tuskish",
 "Flemish",
-"Walloon"
+"Walloon",
+"rfu",
+"rfu",
+"rfu",
+"rfu",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment",
+"Reserved for national assignment"
+};
+
+static
+const char *table10 [] = {
+"Background sound/clean feed",
+"rfu",
+"rfu",
+"rfu",
+"rfu",
+"Zulu",
+"Vietnamese",
+"Uzbek",
+"Urdu",
+"Ukranian",
+"Thai",
+"Telugu",
+"Tatar",
+"Tamil",
+"Tadzhik",
+"Swahili",
+"Sranan Tongo",
+"Somali",
+"Sinhalese",
+"Shona",
+"Serbo-Croat",
+"Rusyn",
+"Russian",
+"Quechua",
+"Pushtu",
+"Punjabi",
+"Persian",
+"Papiamento",
+"Oriya",
+"Nepali",
+"Ndebele",
+"Marathi",
+"Moldavian",
+"Malaysian",
+"Malagasay",
+"Macedonian",
+"Laotian",
+"Korean",
+"Khmer",
+"Kazakh",
+"Kannada",
+"Japanese",
+"Indonesian",
+"Hindi",
+"Hebrew",
+"Hausa",
+"Gurani",
+"Gujurati",
+"Greek",
+"Greek",
+"Georgian",
+"Fulani",
+"Dari",
+"Chuvash",
+"Chinese",
+"Burmese",
+"Bulgarian",
+"Bengali",
+"Belorussian",
+"Bambora",
+"Azerbaijani",
+"Assamese",
+"Armenian",
+"Arabic",
+"Amharic"
 };
 
 const char *simpleDab::get_programm_language_string (int16_t language) {
-	if (language > 43) {
-	   fprintf (stderr, "GUI: wrong language (%d)\n", language);
-	   return table9 [0];
-	}
 	if (language < 0)
 	   return " ";
-	return table9 [language];
+	else if (language < 0x40)
+	   return table9[language];
+	else if (language < 0x7d)
+	   return table10[language-0x40];
+	fprintf(stderr, "GUI: wrong language (%d)\n", language);
+	return table9[0];
 }
 
 


### PR DESCRIPTION
Update the language table 9 and add table 10 based on ETSI TS 101 756 v1.8.1.

Funny enough table 9 supposed to be for "European languages" and Greek language is included in table 10 "Other languages".