### PR TITLE
Add json output to dab-scanner

### DIFF
--- a/dab-scanner/service-printer.cpp
+++ b/dab-scanner/service-printer.cpp
@@ -63,7 +63,7 @@ void	print_ensembleData (FILE *f,
 void	print_audioheader (FILE *f,
                         bool jsonOutput) {
 	if (jsonOutput == false) {
-		fprintf (f, "\nAudio services\nprogram name;country;serviceId;subchannelId;start address;length (CU); bit rate;DAB/DAB+; prot level; code rate; language; program type\n\n");
+		fprintf (f, "\nAudio services\nprogram name;serviceId;subchannelId;start address;length (CU); bit rate;DAB/DAB+; genre; prot level; code rate; language\n\n");
 	}
 }
 
@@ -85,7 +85,7 @@ bool	success;
 	uint8_t countryId = (serviceId >> 12) & 0xF;
 
 	if (jsonOutput == false) {
-		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;\n",
+		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%d;%s;%s;%s;\n",
 	             serviceName. c_str (),
 	             serviceId,
 	             d -> subchId,
@@ -93,6 +93,7 @@ bool	success;
 	             d -> length,
 	             d -> bitRate,
 	             getASCTy  (d -> ASCTy),
+				 d -> programType,
 	             protL. c_str (),
 	             codeRate. c_str (),
 	             getLanguage (d -> language));
@@ -103,7 +104,7 @@ bool	success;
 			*firstService = false;
 		}
 		
-		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"audio\": \"%s\", \"protectionLevel\": \"%s\", \"codeRate\": \"%s\", \"language\": \"%s\" }",
+		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"audio\": \"%s\", \"genre\": \"%d\", \"protectionLevel\": \"%s\", \"codeRate\": \"%s\", \"language\": \"%s\" }",
 	             serviceId,
 	             serviceName. c_str (),
 	             d -> subchId,
@@ -111,6 +112,7 @@ bool	success;
 	             d -> length,
 	             d -> bitRate,
 	             getASCTy  (d -> ASCTy),
+				 d -> programType,
 	             protL. c_str (),
 	             codeRate. c_str (),
 	             getLanguage (d -> language));
@@ -144,7 +146,7 @@ bool	success;
 	uint8_t countryId = (serviceId >> 12) & 0xF;
 	
 	if (jsonOutput == false) {
-		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;;\n",
+		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;%s;\n",
 	             serviceName. c_str (),
 	             serviceId,
 	             d -> subchId,

--- a/dab-scanner/service-printer.cpp
+++ b/dab-scanner/service-printer.cpp
@@ -103,7 +103,7 @@ bool	success;
 			*firstService = false;
 		}
 		
-		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"encoding\": \"%s\", \"protectionLevel\": \"%s\", \"codeRate\": \"%s\", \"language\": \"%s\" }",
+		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"audio\": \"%s\", \"protectionLevel\": \"%s\", \"codeRate\": \"%s\", \"language\": \"%s\" }",
 	             serviceId,
 	             serviceName. c_str (),
 	             d -> subchId,
@@ -120,7 +120,7 @@ bool	success;
 void	print_dataHeader (FILE *f,
                         bool jsonOutput) {
 	if (jsonOutput == false) {
-		fprintf (f, "\n\n\nData Services\nprogram name;;serviceId;subchannelId;start address;length (CU); bit rate; FEC; prot level; appType ; subService ; \n\n");
+		fprintf (f, "\n\n\nData Services\nprogram name;;serviceId;subchannelId;start address;length (CU); bit rate; FEC; prot level; appType; DSCTy; subService; \n\n");
 	}
 }
 
@@ -154,6 +154,7 @@ bool	success;
 	             getFECscheme (d -> FEC_scheme),
 	             protL. c_str (),
 	             getUserApplicationType (d -> appType),
+ 				 getDSCTy (d -> DSCTy),
 	             compnr == 0 ? "no": "yes");
 	} else {
 		if(*firstService == false) {
@@ -162,7 +163,7 @@ bool	success;
 			*firstService = false;
 		}
 
-		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"FEC\": \"%s\", \"protectionLevel\": \"%s\", \"appType\": \"%s\", \"subService\": \"%s\" }",
+		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"FEC\": \"%s\", \"protectionLevel\": \"%s\", \"appType\": \"%s\", \"data\": \"%s\", \"subService\": \"%s\" }",
 	             serviceId,
 	             serviceName. c_str (),
 	             d -> subchId,
@@ -172,6 +173,7 @@ bool	success;
 	             getFECscheme (d -> FEC_scheme),
 	             protL. c_str (),
 	             getUserApplicationType (d -> appType),
+				 getDSCTy (d -> DSCTy),
 	             compnr == 0 ? "no": "yes");
 	}
 }

--- a/dab-scanner/service-printer.cpp
+++ b/dab-scanner/service-printer.cpp
@@ -24,30 +24,55 @@
 #include	"dab_tables.h"
 #include	"dab-api.h"
 
+void	print_fileHeader (FILE *f,
+                        bool jsonOutput) {
+	if (jsonOutput != false) {
+		fprintf (f, "{\n");
+	}
+}
 
 void	print_ensembleData (FILE *f,
+                        bool jsonOutput,
 	                    void *theRadio,
 	                    std::string currentChannel,
 	                    std::string ensembleLabel,
-	                    uint32_t	ensembleId) {
+	                    uint32_t	ensembleId,
+						bool *firstEnsemble) {
 
 	if (ensembleLabel == std::string (""))
 	   return;
 
-	fprintf (f, "\n\nEnsemble %s; ensembleId %X; channel %s; \n\n",
+	if (jsonOutput == false) {
+		fprintf (f, "\n\nEnsemble %s; ensembleId %X; channel %s; \n\n",
 	            ensembleLabel. c_str (),
 	            ensembleId,
 	            currentChannel. c_str ());
+	} else {
+		if(*firstEnsemble == false) {
+			fprintf (f, ",\n");
+		} else {
+			*firstEnsemble = false;
+		}
+		fprintf (f, "    \"%X\": { \"name\": \"%s\", \"channel\": \"%s\", \"services\": {\n",
+	            ensembleId,
+	            ensembleLabel. c_str (),
+	            currentChannel. c_str ());
+	}
 }
 
-void	print_audioheader (FILE *f) {
-	fprintf (f, "\nAudio services\nprogram name;country;serviceId;subchannelId;start address;length (CU); bit rate;DAB/DAB+; prot level; code rate; language; program type\n\n");
+void	print_audioheader (FILE *f,
+                        bool jsonOutput) {
+	if (jsonOutput == false) {
+		fprintf (f, "\nAudio services\nprogram name;country;serviceId;subchannelId;start address;length (CU); bit rate;DAB/DAB+; prot level; code rate; language; program type\n\n");
+	}
 }
 
 void	print_audioService (FILE *f,
+                        bool jsonOutput,
 	                    void *theRadio,
 	                    std::string serviceName,
-	                    audiodata *d) {
+	                    audiodata *d,
+						bool *firstService) {
 bool	success;
 
 	if (!d -> defined)
@@ -58,8 +83,9 @@ bool	success;
 	std::string codeRate	= getCodeRate (d -> shortForm, d -> protLevel);
 	uint32_t serviceId	= dab_getSId (theRadio, serviceName. c_str ());
 	uint8_t countryId = (serviceId >> 12) & 0xF;
-	                          
-	fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;\n",
+
+	if (jsonOutput == false) {
+		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;\n",
 	             serviceName. c_str (),
 	             serviceId,
 	             d -> subchId,
@@ -70,17 +96,41 @@ bool	success;
 	             protL. c_str (),
 	             codeRate. c_str (),
 	             getLanguage (d -> language));
+	} else {
+		if(*firstService == false) {
+			fprintf (f, ",\n");
+		} else {
+			*firstService = false;
+		}
+		
+		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"encoding\": \"%s\", \"protectionLevel\": \"%s\", \"codeRate\": \"%s\", \"language\": \"%s\" }",
+	             serviceId,
+	             serviceName. c_str (),
+	             d -> subchId,
+	             d -> startAddr,
+	             d -> length,
+	             d -> bitRate,
+	             getASCTy  (d -> ASCTy),
+	             protL. c_str (),
+	             codeRate. c_str (),
+	             getLanguage (d -> language));
+	}
 }
 
-void	print_dataHeader (FILE *f) {
-	fprintf (f, "\n\n\nData Services\nprogram name;;serviceId;subchannelId;start address;length (CU); bit rate; FEC; prot level; appType ; subService ; \n\n");
+void	print_dataHeader (FILE *f,
+                        bool jsonOutput) {
+	if (jsonOutput == false) {
+		fprintf (f, "\n\n\nData Services\nprogram name;;serviceId;subchannelId;start address;length (CU); bit rate; FEC; prot level; appType ; subService ; \n\n");
+	}
 }
 
 void	print_dataService (FILE		*f,
+                       bool jsonOutput,
 	                   void		*theRadio,
 	                   std::string	serviceName,
 	                   uint8_t	compnr,
-	                   packetdata	*d) {
+	                   packetdata	*d,
+					   bool *firstService) {
 bool	success;
 
 	if (!d -> defined)
@@ -92,7 +142,9 @@ bool	success;
 	                                       d -> protLevel);
 	uint32_t serviceId	= dab_getSId (theRadio, serviceName. c_str ());
 	uint8_t countryId = (serviceId >> 12) & 0xF;
-	fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;;\n",
+	
+	if (jsonOutput == false) {
+		fprintf (f, "%s;%X;%d;%d;%d;%d;%s;%s;%s;%s;;\n",
 	             serviceName. c_str (),
 	             serviceId,
 	             d -> subchId,
@@ -103,4 +155,37 @@ bool	success;
 	             protL. c_str (),
 	             getUserApplicationType (d -> appType),
 	             compnr == 0 ? "no": "yes");
+	} else {
+		if(*firstService == false) {
+			fprintf (f, ",\n");
+		} else {
+			*firstService = false;
+		}
+
+		fprintf (f, "        \"%X\": { \"name\": \"%s\", \"subchannelId\": \"%d\", \"startAddress\": \"%d\", \"length\": \"%d\", \"bitRate\": \"%d\", \"FEC\": \"%s\", \"protectionLevel\": \"%s\", \"appType\": \"%s\", \"subService\": \"%s\" }",
+	             serviceId,
+	             serviceName. c_str (),
+	             d -> subchId,
+	             d -> startAddr,
+	             d -> length,
+	             d -> bitRate,
+	             getFECscheme (d -> FEC_scheme),
+	             protL. c_str (),
+	             getUserApplicationType (d -> appType),
+	             compnr == 0 ? "no": "yes");
+	}
+}
+
+void	print_ensembleFooter (FILE *f,
+                        bool jsonOutput) {
+	if (jsonOutput != false) {
+		fprintf (f, "\n        }\n    }");
+	}
+}
+
+void	print_fileFooter (FILE *f,
+                        bool jsonOutput) {
+	if (jsonOutput != false) {
+		fprintf (f, "\n}\n");
+	}
 }

--- a/dab-scanner/service-printer.h
+++ b/dab-scanner/service-printer.h
@@ -23,19 +23,33 @@
 #include	"dab_tables.h"
 #include	"dab-api.h"
 
+void	print_fileHeader (FILE *f,
+                        bool jsonOutput);
 void	print_ensembleData (FILE *f,
+                        bool jsonOutput,
 	                    void *theRadio,
 	                    std::string channel,
 	                    std::string ensembleLabel,
-	                    uint32_t ensembleId);
-void	print_audioheader (FILE *f);
+	                    uint32_t ensembleId,
+						bool *firstEnsemble);
+void	print_audioheader (FILE *f,
+                        bool jsonOutput);
 void	print_audioService (FILE *f,
+                        bool jsonOutput,
 	                    void *theRadio,
 	                    std::string serviceName,
-	                    audiodata *d);
-void	print_dataHeader (FILE *f);
+	                    audiodata *d,
+						bool *firstService);
+void	print_dataHeader (FILE *f,
+                        bool jsonOutput);
 void	print_dataService (FILE		*f,
+                       bool jsonOutput,
 	                   void		*theRadio,
 	                   std::string	serviceName,
 	                   uint8_t	compnr,
-	                   packetdata *d);
+	                   packetdata *d,
+					   bool *firstService);
+void	print_ensembleFooter (FILE *f,
+                        bool jsonOutput);
+void	print_fileFooter (FILE *f,
+                        bool jsonOutput);


### PR DESCRIPTION
I need DAB scanning data in an easily parseable format for a project, so I added JSON output to dab-scanner.  It can be selected with -j.
