### PR TITLE
fix listing of audio/data programs

### DIFF
--- a/dab-scanner/main.cpp
+++ b/dab-scanner/main.cpp
@@ -398,7 +398,7 @@ bool firstEnsemble = true;
 	                             programNames [i]. c_str (),
 	                             &ad,
 	                             &firstService);
-	         for (int j = 1; j < 5; j ++) {
+	         for (int j = 0; j < 16; j ++) {
 	            packetdata pd;
 	            dataforDataService (theRadio,
 	                                programNames [i]. c_str (),
@@ -420,7 +420,7 @@ bool firstEnsemble = true;
 	         if (firstTime)
 	            print_dataHeader (outFile, jsonOutput);
 	         firstTime	= false;
-	         for (int j = 0; j < 5; j ++) {
+	         for (int j = 0; j < 16; j ++) {
                     packetdata pd;
                     dataforDataService (theRadio,
                                         programNames [i]. c_str (),
@@ -437,7 +437,7 @@ bool firstEnsemble = true;
 	      }
 	      else
 	      if (is_audioService (theRadio, programNames [i]. c_str ())) {
-	         for (int j = 1; j < 5; j ++) {
+	         for (int j = 0; j < 16; j ++) {
 	            packetdata pd;
 	            dataforDataService (theRadio,
 	                                programNames [i]. c_str (),

--- a/example-10/main.cpp
+++ b/example-10/main.cpp
@@ -1289,7 +1289,7 @@ bool	err;
 	                   SINCE_START , it. second -> programName.c_str(), serviceIdentifier);
 	         }
 
-	         for (int i = 0; i < 5; i ++) {
+	         for (int i = 0; i < 16; i ++) {
 	            audiodata ad;
 	            packetdata pd;
 	            theRadio -> dataforAudioService (


### PR DESCRIPTION
* the SCIds can be 0 .. 15, as the number comes from
  SCIds = getBits_4()
  in fib-decoder.cpp line 791 (HandleFIG0Extension8)
* in older version (my clone), componentNr was used when looking for
  that data e.g. with dataforPacketService(),
  but that was also from getBits_4()
* problem was reported from andimik

Signed-off-by: hayati ayguen <h_ayguen@web.de>