### PR TITLE
Create mot files in binary mode

### DIFF
--- a/library/src/backend/data/mot/mot-object.cpp
+++ b/library/src/backend/data/mot/mot-object.cpp
@@ -174,7 +174,7 @@ std::vector<uint8_t> result;
 #else
 	   realName = "/tmp/" + realName;
 #endif
-	   FILE * temp = fopen (realName. c_str (), "w");
+	   FILE * temp = fopen (realName. c_str (), "wb");
            if (temp) {
 	      fwrite (result.data (), 1, result. size (), temp);
 	      fclose (temp);


### PR DESCRIPTION
Otherwise they are corrupted on Windows. (Should be valid for Linux too)