### PR TITLE
Using fprintf instead of std:err to avoid lags

### DIFF
--- a/example-3/main.cpp
+++ b/example-3/main.cpp
@@ -612,15 +612,16 @@ deviceHandler	*theDevice;
            exit (22);
 	}
         else
-	   cerr << "there might be a DAB signal here" << endl;
+	   fprintf (stderr, "there might be a DAB signal here\n");
 
 	if (!ensembleRecognized. load ())
 	while (!ensembleRecognized. load () &&
                                      (--freqSyncTime >= 0)) {
-           std::cerr << freqSyncTime + 1 << "\r";
+	   fprintf (stderr, "Sleeping 1\n");
+//           std::cerr << freqSyncTime + 1 << std::endl;
            sleep (1);
         }
-        std::cerr << "\n";
+	fprintf (stderr, "\n");;
 
 	if (!ensembleRecognized. load ()) {
 	   fprintf (stderr, "no ensemble data found, fatal\n");
@@ -640,8 +641,7 @@ deviceHandler	*theDevice;
 	   programName = std::string (temp);
 	}
 
-	std::cerr << "we try to start program " <<
-                                                 programName << "\n";
+	fprintf (stderr,"we try to start program %s\n",programName.c_str());
 	if (!is_audioService (theRadio, programName. c_str ())) {
 	   std::cerr << "sorry  we cannot handle service " <<
                                                  programName << "\n";

--- a/example-3/streamer.cpp
+++ b/example-3/streamer.cpp
@@ -66,6 +66,7 @@ bool    streamer::restart (void) {
 void	streamer::addBuffer	(void *buffer, int amount, int elsize) {
 	(void)elsize;
 	if (running. load ())
+//	   fprintf (stderr, "putting data into buffer\n");
 	   theBuffer	-> putDataIntoBuffer (buffer, amount);
 }
 
@@ -77,10 +78,11 @@ int64_t nextStop	= (int64_t)(getMyTime ());
 	running. store (true);
 	while (running. load ()) {
 	   int a = theBuffer -> getDataFromBuffer (lbuf, 2 * 4800);
-//	   fprintf (stderr, " a = %d\n", a);
+//	   fprintf (stderr, "got data from buffer a = %d\n", a);
 	   if (a < 2 * 4800)
 	      memset (&lbuf [a], 0, (4800 * 2 - a) * sizeof (int16_t));
 	   nextStop	= nextStop + period;
+//	   fprintf (stderr, "writing data out\n");
 	   fwrite (lbuf, 2 * 4800, sizeof (int16_t), stdout);
 	   if (nextStop - getMyTime () > 0)
 	      usleep (nextStop - getMyTime ());


### PR DESCRIPTION
Hello Jvan,
I was experiencing a looong time between when the example-3 was started and when sound was actually heard when the program was started by the rtsp server and  stdout and stderr were going to pipes.

The strange thing was that it paused several seconds after writing on stderr "try to start" and when the programName was actually written out.
I suspected the issue was again with the streamer so I added some dumb log lines going to stderr in streamer.cpp and the problem was not showing anymore.

so I did some further test and, I've no idea why, using std:err to output messages was basically hanging everything for several seconds, writing the log lines from the streamed was evidently forcing the flush of some buffer. I removed the new log lines from the streamer and tried to add some std::endl and std::flush here and there but the problem was still there.
Finally I changed the code to use fprintf and everything seems to work smoothly.
