### PR TITLE
fixed rtl_tcp cases for examples 2,3,4

### DIFF
--- a/example-2/main.cpp
+++ b/example-2/main.cpp
@@ -538,7 +538,7 @@ int	theDuration		= -1;	// no limit
 	      case 'I':
 	         basePort	= atoi (optarg);
 	         break;
-	      case "G":
+	      case 'G':
 	         gain		= atoi (optarg);
 	         break;
 

--- a/example-2/main.cpp
+++ b/example-2/main.cpp
@@ -306,8 +306,7 @@ const char	*optionsString	= "T:D:d:M:B:P:O:A:F:R:";
 std::string	fileName;
 bool		repeater	= true;
 const char	*optionsString	= "T:D:d:M:B:P:O:A:F:R:";
-#else
-//	HAVE_RTL_TCP
+#else	HAVE_RTL_TCP
 int		gain		= 50;
 bool		autogain	= false;
 int		ppmOffset	= 0;

--- a/example-2/main.cpp
+++ b/example-2/main.cpp
@@ -306,7 +306,7 @@ const char	*optionsString	= "T:D:d:M:B:P:O:A:F:R:";
 std::string	fileName;
 bool		repeater	= true;
 const char	*optionsString	= "T:D:d:M:B:P:O:A:F:R:";
-#else	HAVE_RTL_TCP
+#elif	HAVE_RTL_TCP
 int		gain		= 50;
 bool		autogain	= false;
 int		ppmOffset	= 0;

--- a/example-3/main.cpp
+++ b/example-3/main.cpp
@@ -477,7 +477,7 @@ deviceHandler	*theDevice;
 	      case 'I':
 	         basePort	= atoi (optarg);
 	         break;
-	      case "G":
+	      case 'G':
 	         gain		= atoi (optarg);
 	         break;
 

--- a/example-3/main.cpp
+++ b/example-3/main.cpp
@@ -297,8 +297,7 @@ const char	*optionsString	= "i:D:d:M:B:P:O:A:F:R:";
 std::string	fileName;
 bool	repeater		= true;
 const char	*optionsString	= "i:D:d:M:B:P:O:A:F:R:";
-#elif
-//	HAVE_RTL_TCP
+#elif	HAVE_RTL_TCP
 int		gain		= 50;
 bool		autogain	= false;
 int		ppmOffset	= 0;

--- a/example-4/main.cpp
+++ b/example-4/main.cpp
@@ -239,8 +239,7 @@ const char	*optionsString	= "D:d:M:B:P:O:A:F:R:f:";
 std::string	fileName;
 bool	repeater		= true;
 const char	*optionsString	= "D:d:M:B:P:O:A:F:R:f:";
-#elif
-//	HAVE_RTL_TCP
+#elif	HAVE_RTL_TCP
 int		gain		= 50;
 bool		autogain	= false;
 int		ppmOffset	= 0;

--- a/example-4/main.cpp
+++ b/example-4/main.cpp
@@ -418,7 +418,7 @@ int	theDuration	= -1;		// infinite
 	      case 'I':
 	         basePort	= atoi (optarg);
 	         break;
-	      case "G":
+	      case 'G':
 	         gain		= atoi (optarg);
 	         break;
 


### PR DESCRIPTION
Fixes the following error in examples

```
/home/andreas/apps/dab-cmdline/example-3/main.cpp: In function ‘int main(int, char**)’:
/home/andreas/apps/dab-cmdline/example-3/main.cpp:441:20: error: conversion from ‘const char*’ to ‘int’ in a converted constant expression
  441 |               case "G":
      |                    ^~~
/home/andreas/apps/dab-cmdline/example-3/main.cpp:441:20: error: could not convert ‘"G"’ from ‘const char [2]’ to ‘int’
  441 |               case "G":
      |                    ^~~
      |                    |
      |                    const char [2]
make[2]: *** [CMakeFiles/dab-rtl_tcp-3.dir/build.make:76: CMakeFiles/dab-rtl_tcp-3.dir/main.cpp.o] Fehler 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/dab-rtl_tcp-3.dir/all] Fehler 2
make: *** [Makefile:136: all] Fehler 2

```