### PR TITLE
Create exceptions and fix minor problem in example 1

### DIFF
--- a/device-handler.h
+++ b/device-handler.h
@@ -30,6 +30,20 @@
 #include	<stdint.h>
 #include	<complex>
 #include	<thread>
+
+#define DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+#define DEBUG_PRINT(...) \
+    do { \
+				printf(__VA_ARGS__); \
+    } while (0)
+#else
+#define DEBUG_PRINT(...) \
+    do { } while (0)
+#endif
+
+
 using namespace std;
 
 class	deviceHandler {
@@ -58,4 +72,3 @@ protected:
 virtual		void	run		(void);
 };
 #endif
-

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -200,7 +200,7 @@ endif()
                            ${CMAKE_DL_LIBS}
     )
 
-    INSTALL (TARGETS ${objectName} 
+    INSTALL (TARGETS ${objectName}
                 LIBRARY DESTINATION ./lib)
 
     INSTALL (FILES ${${objectName}_HDRS} DESTINATION include/${objectName} COMPONENT devel)

--- a/devices/device-exceptions.h
+++ b/devices/device-exceptions.h
@@ -1,0 +1,251 @@
+#include <stdexcept>
+
+#define MAX_MESSAGE_SIZE 256
+
+// Exceptions with input
+class LibNotFound : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      LibNotFound(const char * libraryString) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Library %s not found", libraryString);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class LoadingSymbolsFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      LoadingSymbolsFailed(const char * libraryString) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to load symbols/functions from %s", libraryString);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class CreatingSocketFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      CreatingSocketFailed(char * error) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to open socket because %s", error);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class GettingHostnameFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      GettingHostnameFailed(char * error) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to get hostname because: %s", error);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class ConnectingFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      ConnectingFailed(char * error) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to connect because: %s", error);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class OpeningFileFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      OpeningFileFailed(char * file ,char * error) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to open %s because: %s", file, error);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+class OpeningChannelFailed : public std::exception {
+    private:
+      char message[MAX_MESSAGE_SIZE];
+
+    public:
+      OpeningChannelFailed(char * direction ,char * channel) {
+        snprintf(this->message, MAX_MESSAGE_SIZE, "Unable to open/enable %s channel %s", direction, channel);
+      };
+
+      const char * what () const noexcept override  {
+          return message;
+      }
+
+};
+
+// All exceptions below take no arguments
+
+class DeviceNotFound : public std::exception {
+    private:
+    public:
+      DeviceNotFound(){};
+
+      const char * what () const noexcept override {
+          return "Device not found";
+      }
+};
+
+class OpeningFailed : public std::exception {
+    private:
+    public:
+      OpeningFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to open device";
+      }
+};
+
+class SampleRateFailed : public std::exception {
+    private:
+    public:
+      SampleRateFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to set sample rate";
+      }
+};
+
+class WrongSdrPlayVersion : public std::exception {
+    private:
+    public:
+      WrongSdrPlayVersion(){};
+
+      const char * what () const noexcept override {
+          return "Please upgrade to sdrplay version 2.13";
+      }
+};
+
+class StartingThreadFailed : public std::exception {
+    private:
+    public:
+      StartingThreadFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to start thread";
+      }
+};
+
+class NoInstanceFound : public std::exception {
+    private:
+    public:
+      NoInstanceFound(){};
+
+      const char * what () const noexcept override {
+          return "No instance found";
+      }
+};
+
+class BandwidthFailed : public std::exception {
+    private:
+    public:
+      BandwidthFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to set bandwith";
+      }
+};
+
+class PortSelectFailed : public std::exception {
+    private:
+    public:
+      PortSelectFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to set port";
+      }
+};
+
+class InterfaceFailed : public std::exception {
+    private:
+    public:
+      InterfaceFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to find interface";
+      }
+};
+
+class FrequencyFailed : public std::exception {
+    private:
+    public:
+      FrequencyFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to set frequency";
+      }
+};
+
+class CreatingBufferFailed : public std::exception {
+    private:
+    public:
+      CreatingBufferFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to create buffer";
+      }
+};
+
+class InitFailed : public std::exception {
+    private:
+    public:
+      InitFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to initalize device";
+      }
+};
+
+class GetChannelsFailed : public std::exception {
+    private:
+    public:
+      GetChannelsFailed(){};
+
+      const char * what () const noexcept override {
+          return "Unable to get channels";
+      }
+};
+
+class UnknownError : public std::exception {
+    private:
+    public:
+      UnknownError(){};
+
+      const char * what () const noexcept override {
+          return "Unknown idk either";
+      }
+};

--- a/devices/hackrf-handler/hackrf-handler.cpp
+++ b/devices/hackrf-handler/hackrf-handler.cpp
@@ -23,7 +23,7 @@
  */
 
 #include	"hackrf-handler.h"
-
+#include  "device-exceptions.h"
 #define	DEFAULT_GAIN	30
 
 	hackrfHandler::hackrfHandler  (int32_t	frequency,
@@ -42,39 +42,39 @@ int	res;
 //
 	res	= hackrf_init ();
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_init:");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
-	   throw (21);
+	   DEBUG_PRINT ("Problem with hackrf_init:");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
+	   throw InitFailed();
 	}
 
 	res	= hackrf_open (&theDevice);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_open:");
-	   fprintf (stderr, "%s \n",
+	   DEBUG_PRINT ("Problem with hackrf_open:");
+	   DEBUG_PRINT ("%s \n",
 	                 hackrf_error_name (hackrf_error (res)));
-	   throw (22);
+	   throw OpeningFailed();
 	}
 
 	res	= hackrf_set_sample_rate (theDevice, 2048000.0);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_set_samplerate:");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
-	   throw (23);
+	   DEBUG_PRINT ("Problem with hackrf_set_samplerate:");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
+	   throw SampleRateFailed();
 	}
 
 	res	= hackrf_set_baseband_filter_bandwidth (theDevice,
 	                                                        1750000);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_set_bw:");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
-	   throw (24);
+	   DEBUG_PRINT ("Problem with hackrf_set_bw:");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
+	   throw BandwidthFailed();
 	}
 
 	res	= hackrf_set_freq (theDevice, frequency);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_set_freq: ");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
-	   throw (25);
+	   DEBUG_PRINT ("Problem with hackrf_set_freq: ");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
+	   throw FrequencyFailed();
 	}
 
 	hackrf_device_list_t *deviceList = hackrf_device_list ();
@@ -86,9 +86,9 @@ int	res;
 	   (void) board_id;
 	}
 
-	if ((vgaGain <= 62) && (vgaGain >= 0)) 
+	if ((vgaGain <= 62) && (vgaGain >= 0))
            (void)hackrf_set_vga_gain (theDevice, vgaGain);
-	if ((lnaGain <= 40) && (lnaGain >= 0)) 
+	if ((lnaGain <= 40) && (lnaGain >= 0))
            (void)hackrf_set_lna_gain (theDevice, lnaGain);
 	(void)hackrf_set_amp_enable (theDevice, ampEnable);
 
@@ -109,8 +109,8 @@ int	res;
 	if ((newGain <= 40) && (newGain >= 0)) {
 	   res	= hackrf_set_lna_gain (theDevice, newGain);
 	   if (res != HACKRF_SUCCESS) {
-	      fprintf (stderr, "Problem with hackrf_lna_gain :\n");
-	      fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
+	      DEBUG_PRINT ("Problem with hackrf_lna_gain :\n");
+	      DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
 	      return;
 	   }
 	}
@@ -121,8 +121,8 @@ int	res;
 	if ((newGain <= 62) && (newGain >= 0)) {
 	   res	= hackrf_set_vga_gain (theDevice, newGain);
 	   if (res != HACKRF_SUCCESS) {
-	      fprintf (stderr, "Problem with hackrf_vga_gain :\n");
-	      fprintf (stderr, "%s \n",
+	      DEBUG_PRINT ("Problem with hackrf_vga_gain :\n");
+	      DEBUG_PRINT ("%s \n",
 	                 hackrf_error_name (hackrf_error (res)));
 	      return;
 	   }
@@ -156,24 +156,24 @@ int	res;
 
 	res     = hackrf_set_freq (theDevice, newFrequency);
         if (res != HACKRF_SUCCESS) {
-           fprintf (stderr, "Problem with hackrf_set_freq: \n");
-           fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
+           DEBUG_PRINT ("Problem with hackrf_set_freq: \n");
+           DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
            return false;
         }
         vfoFrequency = newFrequency;
 
-	res	= hackrf_start_rx (theDevice, callback, this);	
+	res	= hackrf_start_rx (theDevice, callback, this);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_start_rx :\n");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
+	   DEBUG_PRINT ("Problem with hackrf_start_rx :\n");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
 	   return false;
 	}
 //
 //	reset the gain(s), since the amp-enable is to be reset
 //	after each change in frequency
-	if ((vgaGain <= 62) && (vgaGain >= 0)) 
+	if ((vgaGain <= 62) && (vgaGain >= 0))
            (void)hackrf_set_vga_gain (theDevice, vgaGain);
-	if ((lnaGain <= 40) && (lnaGain >= 0)) 
+	if ((lnaGain <= 40) && (lnaGain >= 0))
            (void)hackrf_set_lna_gain (theDevice, lnaGain);
 	(void)hackrf_set_amp_enable (theDevice, ampEnable);
 	running. store (hackrf_is_streaming (theDevice));
@@ -188,8 +188,8 @@ int	res;
 
 	res	= hackrf_stop_rx (theDevice);
 	if (res != HACKRF_SUCCESS) {
-	   fprintf (stderr, "Problem with hackrf_stop_rx :");
-	   fprintf (stderr, "%s \n", hackrf_error_name (hackrf_error (res)));
+	   DEBUG_PRINT ("Problem with hackrf_stop_rx :");
+	   DEBUG_PRINT ("%s \n", hackrf_error_name (hackrf_error (res)));
 	   return;
 	}
 	running. store (false);
@@ -198,7 +198,7 @@ int	res;
 //
 //	The brave old getSamples. For the hackrf, we get
 //	size still in I/Q pairs
-int32_t	hackrfHandler::getSamples (std::complex<float> *V, int32_t size) { 
+int32_t	hackrfHandler::getSamples (std::complex<float> *V, int32_t size) {
 	return _I_Buffer	-> getDataFromBuffer (V, size);
 }
 
@@ -213,4 +213,3 @@ void	hackrfHandler::resetBuffer	(void) {
 int16_t	hackrfHandler::bitDepth	(void) {
 	return 8;
 }
-

--- a/devices/rawfiles/rawfiles.cpp
+++ b/devices/rawfiles/rawfiles.cpp
@@ -22,7 +22,7 @@
  *
  * 	File reader:
  *	For the (former) files with 8 bit raw data from the
- *	dabsticks 
+ *	dabsticks
  */
 #include        <stdio.h>
 #include        <unistd.h>
@@ -32,6 +32,7 @@
 #include        <time.h>
 #include        <cstring>
 #include        "rawfiles.h"
+#include        "device-exceptions.h"
 
 static inline
 int64_t         getMyTime       (void) {
@@ -51,10 +52,8 @@ struct timeval  tv;
 	_I_Buffer	= new RingBuffer<std::complex<float>>(__BUFFERSIZE);
 	filePointer	= fopen (f. c_str (), "rb");
 	if (filePointer == NULL) {
-	   fprintf (stderr, "file %s cannot open\n", f. c_str ());
-	   perror ("file ?");
 	   delete _I_Buffer;
-	   throw (31);
+	   throw OpeningFileFailed(f.c_str(),strerror(errno));
 	}
 
 	this	-> eofHandler	= nullptr;
@@ -71,10 +70,8 @@ struct timeval  tv;
 	_I_Buffer	= new RingBuffer<std::complex<float>>(__BUFFERSIZE);
 	filePointer	= fopen (f. c_str (), "rb");
 	if (filePointer == NULL) {
-	   fprintf (stderr, "file %s cannot open\n", f. c_str ());
-	   perror ("file ?");
 	   delete _I_Buffer;
-	   throw (31);
+	   throw OpeningFileFailed(f.c_str(),strerror(errno));
 	}
 	currPos = (int64_t)(fileOffsetInSeconds * 2048000.0 * 2.0 );
 	fseek (filePointer, currPos, SEEK_SET);
@@ -133,7 +130,7 @@ bool	eofReached	= false;
 
 	running. store (true);
 	period		= (32768 * 1000) / (2 * 2048);	// full IQś read
-	fprintf (stderr, "Period = %ld\n", period);
+	DEBUG_PRINT ("Period = %ld\n", period);
 	bi		= new std::complex<float> [bufferSize];
 	nextStop	= getMyTime ();
 	while (running. load ()) {
@@ -169,7 +166,7 @@ bool	eofReached	= false;
 	   if (nextStop - getMyTime () > 0)
 	      usleep (nextStop - getMyTime ());
 	}
-	fprintf (stderr, "taak voor replay eindigt hier\n");
+	// DEBUG_PRINT ("taak voor replay eindigt hier\n");
 }
 /*
  *	length is number of uints that we read.
@@ -185,8 +182,7 @@ uint8_t temp [2 * length];
 	currPos		+= n;
 	if (n < length) {
 	   fseek (filePointer, 0, SEEK_SET);
-//	   fprintf (stderr, "End of file, restarting\n");
+//	   DEBUG_PRINT ("End of file, restarting\n");
 	}
 	return	n / 2;
 }
-

--- a/devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -29,6 +29,7 @@
 
 #include	"rtl-sdr.h"
 #include	"rtlsdr-handler.h"
+#include	"device-exceptions.h"
 
 #include	<chrono>
 #include	<ctime>
@@ -79,7 +80,7 @@ int16_t	deviceCount;
 int32_t	r;
 int16_t	i;
 
-	fprintf (stderr, "going for rtlsdr %d %d\n", frequency, gain);
+	DEBUG_PRINT ("going for rtlsdr %d %d\n", frequency, gain);
 	this	-> frequency	= frequency;
 	this	-> deviceOptions	= deviceOpts ? strdup(deviceOpts) : NULL;
 	this	-> ppmCorrection	= ppmCorrection;
@@ -106,24 +107,23 @@ int16_t	i;
 #endif
 
 	if (Handle == NULL) {
-	   fprintf (stderr, "failed to open %s, fatal\n", libraryString);
-	   throw (41);
+	   DEBUG_PRINT ("failed to open %s, fatal\n", libraryString);
+	   throw LibNotFound(libraryString);
 	}
 
 	libraryLoaded	= true;
 	if (!load_rtlFunctions ())
-	   throw (42);
+	   throw LoadingSymbolsFailed(libraryString);
 //
 //	Ok, from here we have the library functions accessible
 	deviceCount 		= this -> rtlsdr_get_device_count ();
 	if (deviceCount == 0) {
-	   fprintf (stderr, "No devices found, fatal\n");
 #ifdef __MINGW32__
 	   FreeLibrary (Handle);
 #else
 	   dlclose (Handle);
 #endif
-	   throw (43);
+	   throw DeviceNotFound();
 	}
 //
 //	OK, now open the hardware
@@ -137,41 +137,40 @@ int16_t	i;
 			this	-> deviceIndex	= uint16_t(-1);
 	}
 	r			= this -> rtlsdr_open (&device, deviceIndex);
+
 	if (r < 0) {
-	   fprintf (stderr, "Opening rtlsdr failed, fatal\n");
 #ifdef __MINGW32__
 	   FreeLibrary (Handle);
 #else
 	   dlclose (Handle);
 #endif
-	   throw (44);
+	   throw OpeningFailed();
 	}
 
 	open			= true;
 	r			= this -> rtlsdr_set_sample_rate (device,
 	                                                          inputRate);
 	if (r < 0) {
-	   fprintf (stderr, "Setting samplerate failed, fatal\n");
 	   this -> rtlsdr_close (device);
 #ifdef __MINGW32__
 	   FreeLibrary (Handle);
 #else
 	   dlclose (Handle);
 #endif
-	   throw (45);
+	   throw SampleRateFailed();
 	}
 
 	r			= this -> rtlsdr_get_sample_rate (device);
-	fprintf (stderr, "samplerate set to %d\n", r);
+	DEBUG_PRINT ("samplerate set to %d\n", r);
 	rtlsdr_set_tuner_gain_mode (device, 0);
 
 	gainsCount	= rtlsdr_get_tuner_gains (device, NULL);
-	fprintf (stderr, "Supported gain values (%d): ", gainsCount);
+	DEBUG_PRINT ("Supported gain values (%d): ", gainsCount);
 	gains		= new int [gainsCount];
 	gainsCount	= rtlsdr_get_tuner_gains (device, gains);
 	for (i = 0; i < gainsCount; i ++)
-	   fprintf (stderr, "%d.%d ", gains [i] / 10, gains [i] % 10);
-	fprintf (stderr, "\n");
+	   DEBUG_PRINT ("%d.%d ", gains [i] / 10, gains [i] % 10);
+	DEBUG_PRINT ("\n");
 	if (ppmCorrection != 0)
 	   rtlsdr_set_freq_correction (device, ppmCorrection);
 	if (autogain)
@@ -182,7 +181,7 @@ int16_t	i;
 	   theGain = 0;
 	if (theGain >= gainsCount)
 	   theGain = gainsCount - 1;
-	fprintf (stderr, "effective gain: gain %d.%d\n",
+	DEBUG_PRINT ("effective gain: gain %d.%d\n",
 	                              gains [theGain] / 10,
 	                              gains [theGain] % 10);
 	rtlsdr_set_tuner_gain (device, gains [theGain]);
@@ -193,7 +192,7 @@ int16_t	i;
 	_I_Buffer		= new RingBuffer<uint8_t>(1024 * 1024);
 }
 
-	rtlsdrHandler::~rtlsdrHandler	(void) {
+rtlsdrHandler::~rtlsdrHandler	(void) {
 	if (running) { // we are running
 	   this -> rtlsdr_cancel_async (device);
 	   workerHandle. join ();
@@ -204,7 +203,7 @@ int16_t	i;
 	   this -> rtlsdr_close (device);
 	if (this	-> deviceOptions)
 		free( this	-> deviceOptions );
-	if (Handle != NULL) 
+	if (Handle != NULL)
 #ifdef __MINGW32__
 	   FreeLibrary (Handle);
 #else
@@ -251,23 +250,23 @@ void	rtlsdrHandler::stopReader	(void) {
 //
 //	we only have 8 bits, so rather than doing a float division to get
 //	the float value we want, we precompute the possibilities
-static 
+static
 float convTable [] = {
- -128 / 128.0 , -127 / 128.0 , -126 / 128.0 , -125 / 128.0 , -124 / 128.0 , -123 / 128.0 , -122 / 128.0 , -121 / 128.0 , -120 / 128.0 , -119 / 128.0 , -118 / 128.0 , -117 / 128.0 , -116 / 128.0 , -115 / 128.0 , -114 / 128.0 , -113 / 128.0 
-, -112 / 128.0 , -111 / 128.0 , -110 / 128.0 , -109 / 128.0 , -108 / 128.0 , -107 / 128.0 , -106 / 128.0 , -105 / 128.0 , -104 / 128.0 , -103 / 128.0 , -102 / 128.0 , -101 / 128.0 , -100 / 128.0 , -99 / 128.0 , -98 / 128.0 , -97 / 128.0 
-, -96 / 128.0 , -95 / 128.0 , -94 / 128.0 , -93 / 128.0 , -92 / 128.0 , -91 / 128.0 , -90 / 128.0 , -89 / 128.0 , -88 / 128.0 , -87 / 128.0 , -86 / 128.0 , -85 / 128.0 , -84 / 128.0 , -83 / 128.0 , -82 / 128.0 , -81 / 128.0 
-, -80 / 128.0 , -79 / 128.0 , -78 / 128.0 , -77 / 128.0 , -76 / 128.0 , -75 / 128.0 , -74 / 128.0 , -73 / 128.0 , -72 / 128.0 , -71 / 128.0 , -70 / 128.0 , -69 / 128.0 , -68 / 128.0 , -67 / 128.0 , -66 / 128.0 , -65 / 128.0 
-, -64 / 128.0 , -63 / 128.0 , -62 / 128.0 , -61 / 128.0 , -60 / 128.0 , -59 / 128.0 , -58 / 128.0 , -57 / 128.0 , -56 / 128.0 , -55 / 128.0 , -54 / 128.0 , -53 / 128.0 , -52 / 128.0 , -51 / 128.0 , -50 / 128.0 , -49 / 128.0 
-, -48 / 128.0 , -47 / 128.0 , -46 / 128.0 , -45 / 128.0 , -44 / 128.0 , -43 / 128.0 , -42 / 128.0 , -41 / 128.0 , -40 / 128.0 , -39 / 128.0 , -38 / 128.0 , -37 / 128.0 , -36 / 128.0 , -35 / 128.0 , -34 / 128.0 , -33 / 128.0 
-, -32 / 128.0 , -31 / 128.0 , -30 / 128.0 , -29 / 128.0 , -28 / 128.0 , -27 / 128.0 , -26 / 128.0 , -25 / 128.0 , -24 / 128.0 , -23 / 128.0 , -22 / 128.0 , -21 / 128.0 , -20 / 128.0 , -19 / 128.0 , -18 / 128.0 , -17 / 128.0 
-, -16 / 128.0 , -15 / 128.0 , -14 / 128.0 , -13 / 128.0 , -12 / 128.0 , -11 / 128.0 , -10 / 128.0 , -9 / 128.0 , -8 / 128.0 , -7 / 128.0 , -6 / 128.0 , -5 / 128.0 , -4 / 128.0 , -3 / 128.0 , -2 / 128.0 , -1 / 128.0 
-, 0 / 128.0 , 1 / 128.0 , 2 / 128.0 , 3 / 128.0 , 4 / 128.0 , 5 / 128.0 , 6 / 128.0 , 7 / 128.0 , 8 / 128.0 , 9 / 128.0 , 10 / 128.0 , 11 / 128.0 , 12 / 128.0 , 13 / 128.0 , 14 / 128.0 , 15 / 128.0 
-, 16 / 128.0 , 17 / 128.0 , 18 / 128.0 , 19 / 128.0 , 20 / 128.0 , 21 / 128.0 , 22 / 128.0 , 23 / 128.0 , 24 / 128.0 , 25 / 128.0 , 26 / 128.0 , 27 / 128.0 , 28 / 128.0 , 29 / 128.0 , 30 / 128.0 , 31 / 128.0 
-, 32 / 128.0 , 33 / 128.0 , 34 / 128.0 , 35 / 128.0 , 36 / 128.0 , 37 / 128.0 , 38 / 128.0 , 39 / 128.0 , 40 / 128.0 , 41 / 128.0 , 42 / 128.0 , 43 / 128.0 , 44 / 128.0 , 45 / 128.0 , 46 / 128.0 , 47 / 128.0 
-, 48 / 128.0 , 49 / 128.0 , 50 / 128.0 , 51 / 128.0 , 52 / 128.0 , 53 / 128.0 , 54 / 128.0 , 55 / 128.0 , 56 / 128.0 , 57 / 128.0 , 58 / 128.0 , 59 / 128.0 , 60 / 128.0 , 61 / 128.0 , 62 / 128.0 , 63 / 128.0 
-, 64 / 128.0 , 65 / 128.0 , 66 / 128.0 , 67 / 128.0 , 68 / 128.0 , 69 / 128.0 , 70 / 128.0 , 71 / 128.0 , 72 / 128.0 , 73 / 128.0 , 74 / 128.0 , 75 / 128.0 , 76 / 128.0 , 77 / 128.0 , 78 / 128.0 , 79 / 128.0 
-, 80 / 128.0 , 81 / 128.0 , 82 / 128.0 , 83 / 128.0 , 84 / 128.0 , 85 / 128.0 , 86 / 128.0 , 87 / 128.0 , 88 / 128.0 , 89 / 128.0 , 90 / 128.0 , 91 / 128.0 , 92 / 128.0 , 93 / 128.0 , 94 / 128.0 , 95 / 128.0 
-, 96 / 128.0 , 97 / 128.0 , 98 / 128.0 , 99 / 128.0 , 100 / 128.0 , 101 / 128.0 , 102 / 128.0 , 103 / 128.0 , 104 / 128.0 , 105 / 128.0 , 106 / 128.0 , 107 / 128.0 , 108 / 128.0 , 109 / 128.0 , 110 / 128.0 , 111 / 128.0 
+ -128 / 128.0 , -127 / 128.0 , -126 / 128.0 , -125 / 128.0 , -124 / 128.0 , -123 / 128.0 , -122 / 128.0 , -121 / 128.0 , -120 / 128.0 , -119 / 128.0 , -118 / 128.0 , -117 / 128.0 , -116 / 128.0 , -115 / 128.0 , -114 / 128.0 , -113 / 128.0
+, -112 / 128.0 , -111 / 128.0 , -110 / 128.0 , -109 / 128.0 , -108 / 128.0 , -107 / 128.0 , -106 / 128.0 , -105 / 128.0 , -104 / 128.0 , -103 / 128.0 , -102 / 128.0 , -101 / 128.0 , -100 / 128.0 , -99 / 128.0 , -98 / 128.0 , -97 / 128.0
+, -96 / 128.0 , -95 / 128.0 , -94 / 128.0 , -93 / 128.0 , -92 / 128.0 , -91 / 128.0 , -90 / 128.0 , -89 / 128.0 , -88 / 128.0 , -87 / 128.0 , -86 / 128.0 , -85 / 128.0 , -84 / 128.0 , -83 / 128.0 , -82 / 128.0 , -81 / 128.0
+, -80 / 128.0 , -79 / 128.0 , -78 / 128.0 , -77 / 128.0 , -76 / 128.0 , -75 / 128.0 , -74 / 128.0 , -73 / 128.0 , -72 / 128.0 , -71 / 128.0 , -70 / 128.0 , -69 / 128.0 , -68 / 128.0 , -67 / 128.0 , -66 / 128.0 , -65 / 128.0
+, -64 / 128.0 , -63 / 128.0 , -62 / 128.0 , -61 / 128.0 , -60 / 128.0 , -59 / 128.0 , -58 / 128.0 , -57 / 128.0 , -56 / 128.0 , -55 / 128.0 , -54 / 128.0 , -53 / 128.0 , -52 / 128.0 , -51 / 128.0 , -50 / 128.0 , -49 / 128.0
+, -48 / 128.0 , -47 / 128.0 , -46 / 128.0 , -45 / 128.0 , -44 / 128.0 , -43 / 128.0 , -42 / 128.0 , -41 / 128.0 , -40 / 128.0 , -39 / 128.0 , -38 / 128.0 , -37 / 128.0 , -36 / 128.0 , -35 / 128.0 , -34 / 128.0 , -33 / 128.0
+, -32 / 128.0 , -31 / 128.0 , -30 / 128.0 , -29 / 128.0 , -28 / 128.0 , -27 / 128.0 , -26 / 128.0 , -25 / 128.0 , -24 / 128.0 , -23 / 128.0 , -22 / 128.0 , -21 / 128.0 , -20 / 128.0 , -19 / 128.0 , -18 / 128.0 , -17 / 128.0
+, -16 / 128.0 , -15 / 128.0 , -14 / 128.0 , -13 / 128.0 , -12 / 128.0 , -11 / 128.0 , -10 / 128.0 , -9 / 128.0 , -8 / 128.0 , -7 / 128.0 , -6 / 128.0 , -5 / 128.0 , -4 / 128.0 , -3 / 128.0 , -2 / 128.0 , -1 / 128.0
+, 0 / 128.0 , 1 / 128.0 , 2 / 128.0 , 3 / 128.0 , 4 / 128.0 , 5 / 128.0 , 6 / 128.0 , 7 / 128.0 , 8 / 128.0 , 9 / 128.0 , 10 / 128.0 , 11 / 128.0 , 12 / 128.0 , 13 / 128.0 , 14 / 128.0 , 15 / 128.0
+, 16 / 128.0 , 17 / 128.0 , 18 / 128.0 , 19 / 128.0 , 20 / 128.0 , 21 / 128.0 , 22 / 128.0 , 23 / 128.0 , 24 / 128.0 , 25 / 128.0 , 26 / 128.0 , 27 / 128.0 , 28 / 128.0 , 29 / 128.0 , 30 / 128.0 , 31 / 128.0
+, 32 / 128.0 , 33 / 128.0 , 34 / 128.0 , 35 / 128.0 , 36 / 128.0 , 37 / 128.0 , 38 / 128.0 , 39 / 128.0 , 40 / 128.0 , 41 / 128.0 , 42 / 128.0 , 43 / 128.0 , 44 / 128.0 , 45 / 128.0 , 46 / 128.0 , 47 / 128.0
+, 48 / 128.0 , 49 / 128.0 , 50 / 128.0 , 51 / 128.0 , 52 / 128.0 , 53 / 128.0 , 54 / 128.0 , 55 / 128.0 , 56 / 128.0 , 57 / 128.0 , 58 / 128.0 , 59 / 128.0 , 60 / 128.0 , 61 / 128.0 , 62 / 128.0 , 63 / 128.0
+, 64 / 128.0 , 65 / 128.0 , 66 / 128.0 , 67 / 128.0 , 68 / 128.0 , 69 / 128.0 , 70 / 128.0 , 71 / 128.0 , 72 / 128.0 , 73 / 128.0 , 74 / 128.0 , 75 / 128.0 , 76 / 128.0 , 77 / 128.0 , 78 / 128.0 , 79 / 128.0
+, 80 / 128.0 , 81 / 128.0 , 82 / 128.0 , 83 / 128.0 , 84 / 128.0 , 85 / 128.0 , 86 / 128.0 , 87 / 128.0 , 88 / 128.0 , 89 / 128.0 , 90 / 128.0 , 91 / 128.0 , 92 / 128.0 , 93 / 128.0 , 94 / 128.0 , 95 / 128.0
+, 96 / 128.0 , 97 / 128.0 , 98 / 128.0 , 99 / 128.0 , 100 / 128.0 , 101 / 128.0 , 102 / 128.0 , 103 / 128.0 , 104 / 128.0 , 105 / 128.0 , 106 / 128.0 , 107 / 128.0 , 108 / 128.0 , 109 / 128.0 , 110 / 128.0 , 111 / 128.0
 , 112 / 128.0 , 113 / 128.0 , 114 / 128.0 , 115 / 128.0 , 116 / 128.0 , 117 / 128.0 , 118 / 128.0 , 119 / 128.0 , 120 / 128.0 , 121 / 128.0 , 122 / 128.0 , 123 / 128.0 , 124 / 128.0 , 125 / 128.0 , 126 / 128.0 , 127 / 128.0 };
 
 //
@@ -275,7 +274,7 @@ float convTable [] = {
 //	size samples: still in I/Q pairs, but we have to convert the data from
 //	uint8_t to std::complex<float>
 
-int32_t	rtlsdrHandler::getSamples (std::complex<float> *V, int32_t size) { 
+int32_t	rtlsdrHandler::getSamples (std::complex<float> *V, int32_t size) {
 int32_t	amount, i;
 uint8_t	*tempBuffer = (uint8_t *)alloca (2 * size * sizeof (uint8_t));
 //
@@ -306,40 +305,40 @@ bool	rtlsdrHandler::load_rtlFunctions (void) {
 	rtlsdr_get_index_by_serial = (pfnrtlsdr_get_index_by_serial)
 	                       GETPROCADDRESS (Handle, "rtlsdr_get_index_by_serial");
 	if (rtlsdr_get_index_by_serial == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_index_by_serial\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_index_by_serial\n");
 	   return false;
 	}
 	rtlsdr_open	= (pfnrtlsdr_open)
 	                       GETPROCADDRESS (Handle, "rtlsdr_open");
 	if (rtlsdr_open == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_open\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_open\n");
 	   return false;
 	}
 	rtlsdr_close	= (pfnrtlsdr_close)
 	                     GETPROCADDRESS (Handle, "rtlsdr_close");
 	if (rtlsdr_close == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_close\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_close\n");
 	   return false;
 	}
 
 	rtlsdr_set_sample_rate =
 	    (pfnrtlsdr_set_sample_rate)GETPROCADDRESS (Handle, "rtlsdr_set_sample_rate");
 	if (rtlsdr_set_sample_rate == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_sample_rate\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_sample_rate\n");
 	   return false;
 	}
 
 	rtlsdr_get_sample_rate	=
 	    (pfnrtlsdr_get_sample_rate)GETPROCADDRESS (Handle, "rtlsdr_get_sample_rate");
 	if (rtlsdr_get_sample_rate == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_sample_rate\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_sample_rate\n");
 	   return false;
 	}
 
 	rtlsdr_get_tuner_gains		= (pfnrtlsdr_get_tuner_gains)
 	                     GETPROCADDRESS (Handle, "rtlsdr_get_tuner_gains");
 	if (rtlsdr_get_tuner_gains == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_tuner_gains\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_tuner_gains\n");
 	   return false;
 	}
 
@@ -347,100 +346,100 @@ bool	rtlsdrHandler::load_rtlFunctions (void) {
 	rtlsdr_set_tuner_gain_mode	= (pfnrtlsdr_set_tuner_gain_mode)
 	                     GETPROCADDRESS (Handle, "rtlsdr_set_tuner_gain_mode");
 	if (rtlsdr_set_tuner_gain_mode == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_tuner_gain_mode\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_tuner_gain_mode\n");
 	   return false;
 	}
 
 	rtlsdr_set_agc_mode	= (pfnrtlsdr_set_agc_mode)
 	                     GETPROCADDRESS (Handle, "rtlsdr_set_agc_mode");
 	if (rtlsdr_set_agc_mode == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_agc_mode\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_agc_mode\n");
 	   return false;
 	}
 
 	rtlsdr_set_tuner_gain	= (pfnrtlsdr_set_tuner_gain)
 	                     GETPROCADDRESS (Handle, "rtlsdr_set_tuner_gain");
 	if (rtlsdr_set_tuner_gain == NULL) {
-	   fprintf (stderr, "Cound not find rtlsdr_set_tuner_gain\n");
+	   DEBUG_PRINT ("Cound not find rtlsdr_set_tuner_gain\n");
 	   return false;
 	}
 
 	rtlsdr_get_tuner_gain	= (pfnrtlsdr_get_tuner_gain)
 	                     GETPROCADDRESS (Handle, "rtlsdr_get_tuner_gain");
 	if (rtlsdr_get_tuner_gain == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_tuner_gain\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_tuner_gain\n");
 	   return false;
 	}
 	rtlsdr_set_center_freq	= (pfnrtlsdr_set_center_freq)
 	                     GETPROCADDRESS (Handle, "rtlsdr_set_center_freq");
 	if (rtlsdr_set_center_freq == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_center_freq\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_center_freq\n");
 	   return false;
 	}
 
 	rtlsdr_get_center_freq	= (pfnrtlsdr_get_center_freq)
 	                     GETPROCADDRESS (Handle, "rtlsdr_get_center_freq");
 	if (rtlsdr_get_center_freq == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_center_freq\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_center_freq\n");
 	   return false;
 	}
 
 	rtlsdr_reset_buffer	= (pfnrtlsdr_reset_buffer)
 	                     GETPROCADDRESS (Handle, "rtlsdr_reset_buffer");
 	if (rtlsdr_reset_buffer == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_reset_buffer\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_reset_buffer\n");
 	   return false;
 	}
 
 	rtlsdr_read_async	= (pfnrtlsdr_read_async)
 	                     GETPROCADDRESS (Handle, "rtlsdr_read_async");
 	if (rtlsdr_read_async == NULL) {
-	   fprintf (stderr, "Cound not find rtlsdr_read_async\n");
+	   DEBUG_PRINT ("Cound not find rtlsdr_read_async\n");
 	   return false;
 	}
 
 	rtlsdr_get_device_count	= (pfnrtlsdr_get_device_count)
 	                     GETPROCADDRESS (Handle, "rtlsdr_get_device_count");
 	if (rtlsdr_get_device_count == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_device_count\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_device_count\n");
 	   return false;
 	}
 
 	rtlsdr_cancel_async	= (pfnrtlsdr_cancel_async)
 	                     GETPROCADDRESS (Handle, "rtlsdr_cancel_async");
 	if (rtlsdr_cancel_async == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_cancel_async\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_cancel_async\n");
 	   return false;
 	}
 
 	rtlsdr_set_direct_sampling = (pfnrtlsdr_set_direct_sampling)
 	                  GETPROCADDRESS (Handle, "rtlsdr_set_direct_sampling");
 	if (rtlsdr_set_direct_sampling == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_direct_sampling\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_direct_sampling\n");
 	   return false;
 	}
 
 	rtlsdr_set_freq_correction = (pfnrtlsdr_set_freq_correction)
 	                  GETPROCADDRESS (Handle, "rtlsdr_set_freq_correction");
 	if (rtlsdr_set_freq_correction == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_freq_correction\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_freq_correction\n");
 	   return false;
 	}
-	
+
 	rtlsdr_get_device_name = (pfnrtlsdr_get_device_name)
 	                  GETPROCADDRESS (Handle, "rtlsdr_get_device_name");
 	if (rtlsdr_get_device_name == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_get_device_name\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_get_device_name\n");
 	   return false;
 	}
 
 	rtlsdr_set_opt_string = (pfnrtlsdr_set_opt_string)
 	                  GETPROCADDRESS (Handle, "rtlsdr_set_opt_string");
 	if (rtlsdr_get_device_name == NULL) {
-	   fprintf (stderr, "Could not find rtlsdr_set_opt_string\n");
+	   DEBUG_PRINT ("Could not find rtlsdr_set_opt_string\n");
 	}
 
-	fprintf (stderr, "OK, functions seem to be loaded\n");
+	DEBUG_PRINT ("OK, functions seem to be loaded\n");
 	return true;
 }
 
@@ -483,9 +482,9 @@ time_t now;
 	std::string fileName = s + " " + toHex (ensembleId) + " " + timeString + ".iq";
 	outFile			= fopen (fileName. c_str (), "w + b");
 	if (outFile != nullptr)
-	   fprintf (stderr, "opened file %s\n", fileName. c_str ());
+	   DEBUG_PRINT ("opened file %s\n", fileName. c_str ());
 	else
-	   fprintf (stderr, "opening %s failed\n", fileName. c_str ());
+	   DEBUG_PRINT ("opening %s failed\n", fileName. c_str ());
 }
 
 void	rtlsdrHandler::stopDumping	() {
@@ -493,4 +492,3 @@ void	rtlsdrHandler::stopDumping	() {
 	   fclose (outFile);
 	outFile	= nullptr;
 }
-

--- a/devices/rtlsdr-handler/rtlsdr-handler.h
+++ b/devices/rtlsdr-handler/rtlsdr-handler.h
@@ -24,7 +24,7 @@
 #ifndef __RTLSDR_HANDLER__
 #define	__RTLSDR_HANDLER__
 
-#include        <dlfcn.h>
+#include  <dlfcn.h>
 #include	"ringbuffer.h"
 #include	"device-handler.h"
 #include	<thread>
@@ -133,4 +133,3 @@ private:
 	pfnrtlsdr_set_opt_string rtlsdr_set_opt_string;
 };
 #endif
-

--- a/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
+++ b/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
@@ -21,6 +21,7 @@
  */
 
 #include	"sdrplay-handler-v3.h"
+#include	"device-exceptions.h"
 
 
 	sdrplayHandler_v3::sdrplayHandler_v3  (uint32_t	frequency,
@@ -46,7 +47,7 @@
            usleep (1000);
         if (failFlag) {
            threadHandle. join ();
-           throw (21);
+           throw StartingThreadFailed ();
         }
 }
 
@@ -70,7 +71,7 @@ void	sdrplayHandler_v3::stopReader	() {
 //	The brave old getSamples. For the sdrplay, we get
 //	size still in I/Q pairs
 //
-int32_t	sdrplayHandler_v3::getSamples (std::complex<float> *V, int32_t size) { 
+int32_t	sdrplayHandler_v3::getSamples (std::complex<float> *V, int32_t size) {
 	return _I_Buffer. getDataFromBuffer (V, size);
 }
 
@@ -105,7 +106,7 @@ std::complex<float> localBuf [numSamples];
 	   localBuf [i] = std::complex<float> (((float)xi [i]) / denominator,
 	                                         ((float)xq [i]) / denominator);
 	int n = (int)(p -> _I_Buffer. GetRingBufferWriteAvailable ());
-	if (n >= (int)numSamples) 
+	if (n >= (int)numSamples)
 	   p -> _I_Buffer. putDataIntoBuffer (localBuf, numSamples);
 }
 
@@ -192,7 +193,7 @@ int			lna_upperBound;
 	   failFlag	= true;
 	   return;
 	}
-	
+
 	fprintf (stderr, "api version %f detected\n", apiVersion);
 //
 //	lock API while device selection is performed
@@ -223,7 +224,7 @@ int			lna_upperBound;
 //	we have a device, unlock
 	sdrplay_api_UnlockDeviceApi ();
 
-	err	= sdrplay_api_DebugEnable (chosenDevice -> dev, 
+	err	= sdrplay_api_DebugEnable (chosenDevice -> dev,
 	                                         (sdrplay_api_DbgLvl_t)1);
 
 //	retrieve device parameters, so they can be changed if needed
@@ -330,18 +331,18 @@ int			lna_upperBound;
 	running. store (false);
 //	normal exit:
 	err = sdrplay_api_Uninit	(chosenDevice -> dev);
-	if (err != sdrplay_api_Success) 
+	if (err != sdrplay_api_Success)
 	   fprintf (stderr, "sdrplay_api_Uninit failed %s\n",
 	                          sdrplay_api_GetErrorString (err));
 
 	err = sdrplay_api_ReleaseDevice	(chosenDevice);
-	if (err != sdrplay_api_Success) 
+	if (err != sdrplay_api_Success)
 	   fprintf (stderr, "sdrplay_api_ReleaseDevice failed %s\n",
 	                          sdrplay_api_GetErrorString (err));
 
 //	sdrplay_api_UnlockDeviceApi	(); ??
         sdrplay_api_Close               ();
-	if (err != sdrplay_api_Success) 
+	if (err != sdrplay_api_Success)
 	   fprintf (stderr, "sdrplay_api_Close failed %s\n",
 	                          sdrplay_api_GetErrorString (err));
 
@@ -354,4 +355,3 @@ closeAPI:
 	sdrplay_api_ReleaseDevice       (chosenDevice);
         sdrplay_api_Close               ();
 }
-

--- a/devices/stdin-handler/stdin-handler.cpp
+++ b/devices/stdin-handler/stdin-handler.cpp
@@ -19,7 +19,7 @@
  *    along with DAB library; if not, write to the Free Software
  *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * 	stdinHandler 
+ * 	stdinHandler
  *	takes the input bytes from stdin
  */
 #include        <stdio.h>
@@ -30,6 +30,7 @@
 #include        <time.h>
 #include        <cstring>
 #include        "stdin-handler.h"
+#include	      "device-exceptions.h"
 
 static inline
 int64_t         getMyTime       (void) {
@@ -44,12 +45,12 @@ struct timeval  tv;
 //
 	stdinHandler::stdinHandler (void) {
 	_I_Buffer	= new RingBuffer<std::complex<float>>(__BUFFERSIZE);
-	
+
 	filePointer	= stdin;
 	if (filePointer == NULL) {
-	   fprintf (stderr, "Cannot open stdin\n");
+	   DEBUG_PRINT ("Cannot open stdin\n");
 	   delete _I_Buffer;
-	   throw (31);
+	   throw OpeningFileFailed("stdin","idk shouldn't fail");
 	}
 	running. store (false);
 }
@@ -105,7 +106,7 @@ int64_t	nextStop;
 
 	running. store (true);
 	bi		= new std::complex<float> [bufferSize];
-	b2		= new uint8_t [bufferSize * 2]; 
+	b2		= new uint8_t [bufferSize * 2];
 	nextStop	= getMyTime ();
 	while (running. load ()) {
 	   while (_I_Buffer -> WriteSpace () < bufferSize + 10) {
@@ -129,6 +130,5 @@ int64_t	nextStop;
 
 	delete [] b2;
 	delete [] bi;
-	fprintf (stderr, "taak voor replay eindigt hier\n");
+	DEBUG_PRINT ("taak voor replay eindigt hier\n");
 }
-

--- a/devices/wavfiles/wavfiles.cpp
+++ b/devices/wavfiles/wavfiles.cpp
@@ -46,22 +46,22 @@ SF_INFO *sf_info;
 	this	-> repeater	= repeater;
 	this	-> eofHandler	= nullptr;
 	this	-> userData	= nullptr;
-	
+
 	_I_Buffer	= new RingBuffer<std::complex<float>>(__BUFFERSIZE);
 
 	sf_info		= (SF_INFO *)alloca (sizeof (SF_INFO));
 	sf_info	-> format	= 0;
 	filePointer	= sf_open (f. c_str (), SFM_READ, sf_info);
 	if (filePointer == NULL) {
-	   fprintf (stderr, "file %s no legitimate sound file\n", 
+	   DEBUG_PRINT ("file %s no legitimate sound file\n",
 	                                f. c_str ());
-	   throw (24);
+	   throw OpeningFileFailed(f.c_str(),"Not a legitimate sound file");
 	}
 	if ((sf_info -> samplerate != 2048000) ||
 	    (sf_info -> channels != 2)) {
-	   fprintf (stderr, "This is not a recorded DAB file, sorry\n");
+	   DEBUG_PRINT ("This is not a recorded DAB file, sorry\n");
 	   sf_close (filePointer);
-	   throw (25);
+	   throw OpeningFileFailed(f.c_str(),"Not a DAB file");
 	}
 	currPos		= 0;
 	running. store (false);
@@ -83,16 +83,16 @@ SF_INFO *sf_info;
 	sf_info	-> format	= 0;
 	filePointer	= sf_open (f. c_str (), SFM_READ, sf_info);
 	if (filePointer == NULL) {
-	   fprintf (stderr, "file %s no legitimate sound file\n", 
+	   DEBUG_PRINT ("file %s no legitimate sound file\n",
 	                                f. c_str ());
-	   throw (24);
+	   throw OpeningFileFailed(f.c_str(),"Not a legitimate sound file");
 	}
 
 	if ((sf_info -> samplerate != 2048000) ||
 	    (sf_info -> channels != 2)) {
-	   fprintf (stderr, "This is not a recorded DAB file, sorry\n");
+	   DEBUG_PRINT ("This is not a recorded DAB file, sorry\n");
 	   sf_close (filePointer);
-	   throw (25);
+	   throw OpeningFileFailed(f.c_str(),"Not a DAB file");
 	}
 
 	currPos = (int64_t)(fileOffsetInSeconds * 2048000.0 );
@@ -154,7 +154,7 @@ bool	eofReached	= false;
 
 	running. store (true);
 	period		= (32768 * 1000) / 2048;	// full IQś read
-	fprintf (stderr, "Period = %ld\n", period);
+	DEBUG_PRINT ("Period = %ld\n", period);
 	bi		= new std::complex<float> [bufferSize];
 	nextStop	= getMyTime ();
 	while (running. load ()) {
@@ -188,7 +188,7 @@ bool	eofReached	= false;
 	   if (nextStop - getMyTime () > 0)
 	      usleep (nextStop - getMyTime ());
 	}
-	fprintf (stderr, "taak voor replay eindigt hier\n");
+	DEBUG_PRINT ("taak voor replay eindigt hier\n");
 	delete [] bi;
 }
 /*
@@ -201,10 +201,9 @@ float	temp [2 * length];
 	n = sf_readf_float (filePointer, temp, length);
 	if (n < length) {
 	   sf_seek (filePointer, 0, SEEK_SET);
-//	   fprintf (stderr, "End of file, restarting\n");
+//	   DEBUG_PRINT ("End of file, restarting\n");
 	}
 	for (i = 0; i < n; i ++)
 	   data [i] = std::complex<float> (temp [2 * i], temp [2 * i + 1]);
 	return	n & ~01;
 }
-

--- a/devices/xml-filereader/xml-filereader.cpp
+++ b/devices/xml-filereader/xml-filereader.cpp
@@ -40,23 +40,22 @@
 	_I_Buffer	= new RingBuffer<std::complex<float>>(INPUT_FRAMEBUFFERSIZE);
 	theFile	= fopen (fileName.c_str (), "rb");
 	if (theFile == nullptr) {
-	   fprintf (stderr, "file %s cannot open\n",
+	   DEBUG_PRINT ("file %s cannot open\n",
 	                                   fileName. c_str ());
-	   perror ("file ?");
 	   delete _I_Buffer;
-	   throw (31);
+	   throw OpeningFileFailed(fileName.c_str(),strerror(errno));
 	}
-	
+
 	bool	ok	= false;
 	theDescriptor	= new xmlDescriptor (theFile, &ok);
 	if (!ok) {
-	   fprintf (stderr, "%s probably not an xml file\n",
+	   DEBUG_PRINT ("%s probably not an xml file\n",
 	                               fileName. c_str ());
 	   delete _I_Buffer;
-	   throw (32);
+	   throw OpeningFileFailed(fileName.c_str(),"Not a xml file");
 	}
 
-	fprintf (stderr, "nrElements = %d\n",
+	DEBUG_PRINT ("nrElements = %d\n",
 	             theDescriptor -> blockList [0].nrElements);
 	theReader	= nullptr;
 }
@@ -108,4 +107,3 @@ int32_t	xml_fileReader::Samples	() {
 	   return 0;
 	return _I_Buffer -> GetRingBufferReadAvailable();
 }
-

--- a/example-1/CMakeLists.txt
+++ b/example-1/CMakeLists.txt
@@ -156,7 +156,7 @@ endif ()
             message(FATAL_ERROR "please install portaudio V19")
         endif ()
         list(APPEND extraLibs ${PORTAUDIO_LIBRARIES})
-	
+
 
 	set (${objectName}_HDRS
 	     ${${objectName}_HDRS}
@@ -206,4 +206,3 @@ configure_file(
 
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-

--- a/example-1/main.cpp
+++ b/example-1/main.cpp
@@ -82,7 +82,7 @@ void	syncsignalHandler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblename_Handler (const char *name, int Id, void *userData) {
@@ -164,7 +164,7 @@ static
 void	mscQuality	(int16_t fe, int16_t rsE, int16_t aacE, void *ctx) {
 //	fprintf (stderr, "msc quality = %d %d %d\n", fe, rsE, aacE);
 }
-	
+
 int	main (int argc, char **argv) {
 // Default values
 uint8_t		theMode		= 1;
@@ -186,7 +186,7 @@ bandHandler	dabBand;
 deviceHandler	*theDevice;
 
 	fprintf (stderr, "dab_cmdline, \
-	                  Copyright 2017 J van Katwijk, Lazy Chair Computing");
+	                  Copyright 2017 J van Katwijk, Lazy Chair Computing\n");
 	timeSynced.	store (false);
 	timesyncSet.	store (false);
 	run.		store (false);
@@ -197,7 +197,7 @@ deviceHandler	*theDevice;
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'B':
@@ -284,7 +284,8 @@ deviceHandler	*theDevice;
 	                                     0);
 #endif
 	}
-	catch (int e) {
+	catch (std::exception& ex) {
+     printf("Exception : %s\n",ex.what());
 	   fprintf (stderr, "allocating device failed, fatal\n");
 	   exit (32);
 	}
@@ -383,7 +384,7 @@ deviceHandler	*theDevice;
 	}
 
 	audiodata ad;
-	if (run. store ) {
+	if (run. load() ) {
 	   dataforAudioService (theRadio, programName. c_str (), &ad, 0);
 	   if (!ad. defined) {
 	      std::cerr << "sorry  we cannot handle service " <<
@@ -402,4 +403,3 @@ deviceHandler	*theDevice;
 	theDevice	-> stopReader ();
 	dabExit (theRadio);
 }
-

--- a/example-2/main.cpp
+++ b/example-2/main.cpp
@@ -113,7 +113,7 @@ void	syncsignalHandler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblenameHandler (const char *name, int Id, void *userData) {
@@ -163,7 +163,7 @@ void	dataOut_Handler (const char * dynamicLabel, void *ctx) {
 //
 //	The function is called from the MOT handler, with
 //	as parameters the filename where the picture is stored
-//	d denotes the subtype of the picture 
+//	d denotes the subtype of the picture
 //	typedef void (*motdata_t)(std::string, int, void *);
 void	motdata_Handler (uint8_t *data, int size,
 	                const char *s, int d, void *ctx) {
@@ -271,13 +271,13 @@ const char	*optionsString	= "T:D:d:M:B:P:O:A:C:G:g:X:";
 int16_t		gain		= 60;
 bool		autogain	= true;
 const char	*optionsString	= "T:D:d:M:B:P:O:A:C:G:Q";
-#elif	HAVE_SDRPLAY	
+#elif	HAVE_SDRPLAY
 int16_t		GRdB		= 30;
 int16_t		lnaState	= 4;
 bool		autogain	= true;
 int16_t		ppmOffset	= 0;
 const char	*optionsString	= "T:D:d:M:B:P:O:A:C:G:L:Qp:";
-#elif	HAVE_SDRPLAY_V3	
+#elif	HAVE_SDRPLAY_V3
 int16_t		GRdB		= 30;
 int16_t		lnaState	= 3;
 bool		autogain	= false;
@@ -355,7 +355,7 @@ int	theDuration		= -1;	// no limit
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'B':
@@ -415,14 +415,14 @@ int	theDuration		= -1;	// no limit
 	      case 'C':
 	         theChannel	= std::string (optarg);
 	         break;
-	
+
 	      case 'p':
 	         ppmOffset	= 0;
 	         break;
 
 #elif	HAVE_LIME
 	      case 'G':
-	      case 'g':	
+	      case 'g':
 	         gain		= atoi (optarg);
 	         break;
 
@@ -613,9 +613,10 @@ int	theDuration		= -1;	// no limit
 #endif
 
 	}
-	catch (int e) {
+	catch (std::exception& ex) {
 	   std::cerr << "allocating device failed (" << e << "), fatal\n";
-	   exit (32);
+		 printf("Exception : %s\n",ex.what());
+	   exit (1);
 	}
 	if (theDevice == nullptr) {
 	   fprintf (stderr, "no device selected, fatal\n");
@@ -705,7 +706,7 @@ int	theDuration		= -1;	// no limit
 	                                         programName << "\n";
 	audiodata ad;
 	if (!is_audioService (theRadio, programName. c_str ())) {
-	   std::cerr << "sorry  we cannot handle service " << 
+	   std::cerr << "sorry  we cannot handle service " <<
 	                                         programName << "\n";
 	   run. store (false);
 	   sleep (1);
@@ -718,7 +719,7 @@ int	theDuration		= -1;	// no limit
 	   dataforAudioService (theRadio,
 	                     programName. c_str (), &ad, 0);
 	   if (!ad. defined) {
-	      std::cerr << "sorry  we cannot handle service " << 
+	      std::cerr << "sorry  we cannot handle service " <<
 	                                         programName << "\n";
 	      run. store (false);
 	   }
@@ -737,12 +738,12 @@ int	theDuration		= -1;	// no limit
 	theDevice	-> stopReader ();
 //	dabReset (theRadio);
 	dabExit  (theRadio);
-	delete theDevice;	
+	delete theDevice;
 	delete soundOut;
 }
 
 void    printOptions (void) {
-	std::cerr << 
+	std::cerr <<
 "                          dab-cmdline options are\n"
 "	                  -T Duration\tstop after <Duration> seconds\n"
 "	                  -M Mode\tMode is 1, 2 or 4. Default is Mode 1\n"
@@ -791,4 +792,3 @@ void    printOptions (void) {
 "	                  -X antenna selection\n"
 "	                  -C channel\n";
 }
-

--- a/example-3/main.cpp
+++ b/example-3/main.cpp
@@ -112,7 +112,7 @@ void	syncsignal_Handler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblename_Handler (const char * name, int Id, void *userData) {
@@ -267,7 +267,7 @@ const char	*optionsString	= "i:T:D:d:M:B:P:O:A:C:G:g:p:";
 int16_t		gain		= 70;
 std::string	antenna		= "Auto";
 const char	*optionsString	= "i:T:D:d:M:B:P:O:A:C:G:g:X:";
-#elif	HAVE_SDRPLAY	
+#elif	HAVE_SDRPLAY
 int16_t		GRdB		= 30;
 int16_t		lnaState	= 2;
 bool		autogain	= false;
@@ -338,7 +338,7 @@ deviceHandler	*theDevice;
 	      case 'T':
 	         theDuration	= 60 * atoi (optarg);
 	         break;
-	   
+
 	      case 'D':
 	         freqSyncTime	= atoi (optarg);
 	         break;
@@ -350,7 +350,7 @@ deviceHandler	*theDevice;
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'B':
@@ -389,14 +389,14 @@ deviceHandler	*theDevice;
 	      case 'C':
 	         theChannel	= std::string (optarg);
 	         break;
-	
+
 	      case 'p':
 	         ppmOffset	= 0;
 	         break;
 
 #elif	HAVE_LIME
 	      case 'G':
-	      case 'g':	
+	      case 'g':
 	         gain		= atoi (optarg);
 	         break;
 
@@ -554,9 +554,10 @@ deviceHandler	*theDevice;
 	                                      ppmOffset);
 #endif
 	}
-	catch (int e) {
+	catch (std::exception& ex) {
 	   fprintf (stderr, "allocating device failed (%d), fatal\n", e);
-	   exit (32);
+     printf("Exception : %s\n",ex.what());
+	   exit (1);
 	}
 #ifdef	STREAMER_OUTPUT
 	theStreamer	= new streamer ();
@@ -658,7 +659,7 @@ deviceHandler	*theDevice;
 
 	dabReset_msc (theRadio);
 	set_audioChannel (theRadio, &ad);
-	
+
 	while (run. load () && (theDuration != 0)) {
 	   if (theDuration > 0)
 	      theDuration --;
@@ -667,11 +668,11 @@ deviceHandler	*theDevice;
 	theDevice	-> stopReader ();
 	dabStop (theRadio);
 	dabExit	(theRadio);
-	delete theDevice;	
+	delete theDevice;
 }
 
 void    printOptions (void) {
-        std::cerr << 
+        std::cerr <<
 "                          dab-cmdline options are\n"
 "	                  -i path\tsave dynamic label and MOT slide to <path>\n"
 "	                  -T duration\thalt after <duration>  minutes\n"
@@ -719,6 +720,3 @@ void    printOptions (void) {
 "                         -X antenna selection\n"
 "                         -C channel\n";
 }
-
-                          
-

--- a/example-4/main.cpp
+++ b/example-4/main.cpp
@@ -99,7 +99,7 @@ void	syncsignal_Handler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblename_Handler (const char *name, int Id, void *userData) {
@@ -215,7 +215,7 @@ const char	*optionsString	= "T:D:d:M:B:P:O:A:C:G:g:p:f:";
 int16_t		gain		= 70;
 std::string	antenna		= "Auto";
 const char	*optionsString	= "T:D:d:M:B:P:O:A:C:G:g:X:f:";
-#elif	HAVE_SDRPLAY	
+#elif	HAVE_SDRPLAY
 int16_t		GRdB		= 30;
 int16_t		lnaState	= 2;
 bool		autogain	= false;
@@ -287,7 +287,7 @@ int	theDuration	= -1;		// infinite
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'B':
@@ -330,14 +330,14 @@ int	theDuration	= -1;		// infinite
 	      case 'C':
 	         theChannel	= std::string (optarg);
 	         break;
-	
+
 	      case 'p':
 	         ppmOffset	= 0;
 	         break;
 
 #elif	HAVE_LIME
 	      case 'G':
-	      case 'g':	
+	      case 'g':
 	         gain		= atoi (optarg);
 	         break;
 
@@ -480,10 +480,12 @@ int	theDuration	= -1;		// infinite
 	                                      ppmOffset);
 #endif
 	}
-	catch (int e) {
+	catch (std::exception& ex) {
 	   std::cerr << "allocating device failed (" << e << "), fatal\n";
-	   exit (32);
+     printf("Exception : %s\n",ex.what());
+	   exit (1);
 	}
+
 //
 //	and with a sound device we now can create a "backend"
 	API_struct interface;
@@ -591,11 +593,11 @@ int	theDuration	= -1;		// infinite
 	theDevice	-> stopReader ();
 	dabStop	(theRadio);
 	dabExit	(theRadio);
-	delete theDevice;	
+	delete theDevice;
 }
 
 void    printOptions (void) {
-        std::cerr << 
+        std::cerr <<
 "                          dab-cmdline options are\n"
 "	                  -T duration\t stop after <duration> minutes\n"
 "	                  -M Mode\tMode is 1, 2 or 4. Default is Mode 1\n"
@@ -642,4 +644,3 @@ void    printOptions (void) {
 "                         -X antenna selection\n"
 "                         -C channel\n";
 }
-

--- a/example-5/main.cpp
+++ b/example-5/main.cpp
@@ -114,7 +114,7 @@ void	syncsignal_Handler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblename_Handler (const char * name, int Id, void *userData) {
@@ -291,7 +291,7 @@ bool	err;
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'B':
@@ -404,9 +404,10 @@ bool	err;
 #endif
 
 	}
-	catch (int e) {
-	   fprintf (stderr, "allocating device failed (%d), fatal\n", e);
-	   exit (32);
+  catch (std::exception& ex) {
+	   std::cerr << "allocating device failed (" << e << "), fatal\n";
+     printf("Exception : %s\n",ex.what());
+	   exit (1);
 	}
 //
 	if (soundOut == NULL) {	// not bound to a file?
@@ -528,7 +529,7 @@ bool	err;
 	keyboard_listener. join ();
 	dabStop	(theRadio);
 	dabExit	(theRadio);
-	delete theDevice;	
+	delete theDevice;
 	delete soundOut;
 }
 
@@ -572,7 +573,7 @@ int16_t	foundIndex	= -1;
 	   if (matches (programNames [i], programName)) {
 	      if (i == programNames. size () - 1)
 	         foundIndex = 0;
-	      else 
+	      else
 	         foundIndex = i + 1;
 	      break;
 	   }
@@ -611,7 +612,7 @@ void	listener	(void) {
 	   char t = getchar ();
 	   message m;
 	   switch (t) {
-	      case '\n': 
+	      case '\n':
 	         m.key = S_NEXT;
 	         m. string = "";
 	         messageQueue. push (m);
@@ -621,4 +622,3 @@ void	listener	(void) {
 	   }
 	}
 }
-

--- a/example-6/main.cpp
+++ b/example-6/main.cpp
@@ -88,7 +88,7 @@ void	syncsignalHandler (bool b, void *userData) {
 //	This function is called whenever the dab engine has taken
 //	some time to gather information from the FIC bloks
 //	the Boolean b tells whether or not an ensemble has been
-//	recognized, the names of the programs are in the 
+//	recognized, the names of the programs are in the
 //	ensemble
 static
 void	ensemblename_Handler (const char *name, int Id, void *userData) {
@@ -137,9 +137,9 @@ void	dataOut_Handler (const char *dynamicLabel, void *ctx) {
 //
 //	The function is called from the MOT handler, with
 //	as parameters the filename where the picture is stored
-//	d denotes the subtype of the picture 
+//	d denotes the subtype of the picture
 //	typedef void (*motdata_t)(std::string, int, void *);
-void	motdata_Handler (uint8_t * data, int size, 
+void	motdata_Handler (uint8_t * data, int size,
 	                 const char *name, int d, void *ctx) {
 	(void)data; (void)size; (void)name; (void)d; (void)ctx;
 //	fprintf (stderr, "plaatje %s\n", s. c_str ());
@@ -244,7 +244,7 @@ bool	err;
 	      case 'M':
 	         theMode	= atoi (optarg);
 	         if (!((theMode == 1) || (theMode == 2) || (theMode == 4)))
-	            theMode = 1; 
+	            theMode = 1;
 	         break;
 
 	      case 'P':
@@ -281,9 +281,10 @@ bool	err;
 	try {
 	   theDevice	= new stdinHandler ();
 	}
-	catch (int e) {
+  catch (std::exception& ex) {
 	   std::cerr << "allocating device failed (" << e << "), fatal\n";
-	   exit (32);
+     printf("Exception : %s\n",ex.what());
+	   exit (1);
 	}
 //
 	if (soundOut == NULL) {	// not bound to a file?
@@ -367,7 +368,7 @@ bool	err;
                                                  programName << "\n";
 	audiodata ad;
 	if (!is_audioService (theRadio, programName. c_str ())) {
-	   std::cerr << "sorry  we cannot handle service " << 
+	   std::cerr << "sorry  we cannot handle service " <<
 	                                         programName << "\n";
 	   run. store (false);
 	}
@@ -376,7 +377,7 @@ bool	err;
 	   dataforAudioService (theRadio,
 	                     programName. c_str (), &ad, 0);
 	   if (!ad. defined) {
-	      std::cerr << "sorry  we cannot handle service " << 
+	      std::cerr << "sorry  we cannot handle service " <<
 	                                         programName << "\n";
 	      run. store (false);
 	   }
@@ -392,12 +393,12 @@ bool	err;
 	theDevice	-> stopReader ();
 	dabReset (theRadio);
 	dabExit  (theRadio);
-	delete theDevice;	
+	delete theDevice;
 	delete soundOut;
 }
 
 void    printOptions (void) {
-        std::cerr << 
+        std::cerr <<
 "                          dab-cmdline options are\n\
                           -D number   amount of time to look for an ensemble\n\
 	                  -d number   seconds within a time sync should be reached\n\
@@ -407,4 +408,3 @@ void    printOptions (void) {
                           -A name     select the audio channel (portaudio)\n\
 	                  -O filename put the output into a file rather than through portaudio\n";
 }
-


### PR DESCRIPTION
This is the pr discussed in #93. It replaces the old exceptions, which where just numbers, with actual exception classes. Also a typo in example 1 is fixed were run.store and run.load was switched up. Some fprintf's were also replaced with DEBUG_PRINT's.