### PR TITLE
Fix alloc-dealloc-mismatch

### DIFF
--- a/library/src/ofdm/freq-interleaver.cpp
+++ b/library/src/ofdm/freq-interleaver.cpp
@@ -84,7 +84,7 @@ int16_t	i;
 //
 //
 	interLeaver::~interLeaver (void) {
-	delete	permTable;
+	delete [] permTable;
 }
 //
 //	according to the standard, the map is a function from


### PR DESCRIPTION
This PR fixes an error found with AddressSanitizer:
```
ERROR: AddressSanitizer: alloc-dealloc-mismatch(operator new [] vs operator delete) on 0x52100123a500
    #0 0x7ff89b8f50f8 in operator delete(void*) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:152
    #1 0x7ff863c13f11 in interLeaver::~interLeaver() (/opt/install/libdab/lib/libdab_lib.so+0x13f11)
```