### PR TITLE
Fix library build on Windows

### DIFF
--- a/device-handler.h
+++ b/device-handler.h
@@ -59,8 +59,6 @@
 #endif
 
 
-using namespace std;
-
 class	deviceHandler {
 public:
 			deviceHandler 	();

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -140,7 +140,8 @@ set (${objectName}_SRCS
     ${${objectName}_SRCS}
     ./dab-api.cpp
     ./src/dab-processor.cpp
-    ./src/ofdm/ofdm-decoder.cpp
+    ./src/time-converter.cpp
+    ./src/ofdm/ensemble.cpp
     ./src/ofdm/phasereference.cpp
     ./src/ofdm/phasetable.cpp
     ./src/ofdm/freq-interleaver.cpp
@@ -148,6 +149,7 @@ set (${objectName}_SRCS
     ./src/ofdm/sample-reader.cpp
     ./src/ofdm/timesyncer.cpp
     ./src/ofdm/fic-handler.cpp
+    ./src/ofdm/fib-config.cpp
     ./src/ofdm/fib-decoder.cpp
     ./src/ofdm/tii-detector.cpp
     ./src/backend/firecode-checker.cpp

--- a/library/includes/support/dab-semaphore.h
+++ b/library/includes/support/dab-semaphore.h
@@ -26,6 +26,7 @@
 #include	<thread>
 #include	<mutex>
 #include	<condition_variable>
+#include	<chrono>
 
 class	Semaphore {
 private:

--- a/library/src/ofdm/tii-detector.cpp
+++ b/library/src/ofdm/tii-detector.cpp
@@ -155,11 +155,11 @@ void	TII_Detector::reset() {
 //	To eliminate (reduce?) noise in the input signal, we might
 //	add a few spectra before computing (up to the user)
 void	TII_Detector::addBuffer (const std::vector<Complex>  &v) {
-Complex tmpBuffer [T_u];
+std::vector<Complex> tmpBuffer (T_u);
 
 	for (int i = 0; i < T_u; i ++)
            tmpBuffer [i] = v [T_g + i] * window [i];
-	my_fftHandler. fft (tmpBuffer);
+	my_fftHandler. fft (tmpBuffer.data());
 	for (int i = 0; i < T_u; i ++)
 	   nullSymbolBuffer [i] += tmpBuffer [i];
 }
@@ -167,9 +167,9 @@ Complex tmpBuffer [T_u];
 void	TII_Detector::collapse (const Complex *inVec,
 	                          Complex *etsiVec, Complex *nonetsiVec,
 	                          bool tiiFilter) {
-Complex buffer [carriers / 2];
+std::vector<Complex> buffer (carriers / 2);
 bool	carrierDelete	= false;
-	memcpy (buffer, inVec, carriers / 2 * sizeof (Complex));
+	memcpy (buffer.data(), inVec, carriers / 2 * sizeof (Complex));
 
 	int nrSections	= tiiFilter ? 2 : 4;
 //	a single carrier cannot be a TII carrier.


### PR DESCRIPTION
Hi Jan,

Here are a few changes to fix building of the library with MSVC on Windows.

In library/src/ofdm/tii-detector.cpp I've changed the VLAs to std::vector, as VLAs are not supported by MSVC.

In dab-demaphore.h, I've included chrono, to define system_clock.

In CMakeLists.txt, I've added some source files that are missing.

In device-handler,h, I've removed using namespace std, as this defines a type named byte, which clashes with Windows SDK definitions. The library seems to use std:: prefix anyway.

Thanks,
Jon
